### PR TITLE
fix: validate correct jail in logs case

### DIFF
--- a/f2b
+++ b/f2b
@@ -728,7 +728,7 @@ if [ "$F2B_ARG1" == "logs" ]; then
     ;;
   *)
     # Show logs for a specific jail
-    f2b_jail_exists "$F2B_ARG3"
+    f2b_jail_exists "$F2B_ARG2"
     f2b_jail_get_log_entries "$F2B_ARG2"
     exit 0
     ;;


### PR DESCRIPTION
## Summary
- fix wrong argument when validating logs command jail existence

## Testing
- `shellcheck f2b`

------
https://chatgpt.com/codex/tasks/task_e_68622e0af28c832f9082d804d09631bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the jail selection in the "logs" command to ensure log entries are displayed for the intended jail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->