### PR TITLE
fix: correct jail checks and add tests

### DIFF
--- a/tests/f2b.bats
+++ b/tests/f2b.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PATH="$BATS_TEST_DIRNAME/bin:$PATH"
+  mkdir -p "$BATS_TEST_DIRNAME/bin"
+  cat > "$BATS_TEST_DIRNAME/bin/fail2ban-client" <<'MOCK'
+#!/usr/bin/env bash
+cmd=$1
+shift
+case "$cmd" in
+  ping)
+    echo "pong"
+    ;;
+  status)
+    if [ -z "$1" ]; then
+      echo "Status"
+      echo "|- Number of jail:      2"
+      echo "\`- Jail list:   sshd, testjail"
+    else
+      echo "Status for the jail: $1"
+    fi
+    ;;
+  -V)
+    echo "0.11.2"
+    ;;
+  *)
+    echo "Mocked fail2ban-client: $cmd $*"
+    ;;
+ esac
+MOCK
+  chmod +x "$BATS_TEST_DIRNAME/bin/fail2ban-client"
+}
+
+@test "status invalid jail" {
+  run "$BATS_TEST_DIRNAME/../f2b" status invalid
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Error: Jail 'invalid' does not exist."* ]]
+}
+
+@test "logs invalid jail" {
+  run "$BATS_TEST_DIRNAME/../f2b" logs invalid
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Error: Jail 'invalid' does not exist."* ]]
+}
+
+@test "logs valid jail" {
+  run "$BATS_TEST_DIRNAME/../f2b" logs sshd
+  [ "$status" -eq 0 ]
+}

--- a/tests/f2b.bats
+++ b/tests/f2b.bats
@@ -26,7 +26,7 @@ case "$cmd" in
   *)
     echo "Mocked fail2ban-client: $cmd $*"
     ;;
- esac
+esac
 MOCK
   chmod +x "$BATS_TEST_DIRNAME/bin/fail2ban-client"
 }


### PR DESCRIPTION
## Summary
- fix argument check in `f2b_jail_exists`
- validate jail name correctly for `logs`
- use jail array when watching all logs
- add Bats-based tests with mocked `fail2ban-client`

## Testing
- `shellcheck f2b`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68622d3ae69c832f924bba91b7a0fd9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved jail validation and argument handling in log-related commands to ensure accurate error detection and log retrieval.
  * Corrected iteration over jail lists for log polling to enhance reliability.

* **Tests**
  * Added new automated tests to verify error handling and correct behavior for jail status and log commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->