### PR TITLE
fix: calculate ban expiration correctly

### DIFF
--- a/f2b
+++ b/f2b
@@ -482,11 +482,11 @@ f2b_banned_ips() {
     local BAN_EXPIRES_SECS=""
     BAN_EXPIRES_SECS=$(date -d "$BAN_EXPIRES" +%s)
     # Calculate the time remaining until the IP is unbanned
-    local BAN_REMAINING=$((BAN_EXPIRES_SECS - CURRENT_TIME))
+    local BAN_REMAINING_SECS=$((BAN_EXPIRES_SECS - CURRENT_TIME))
 
     # Format the time remaining until the IP is unbanned
     local BAN_REMAINING=""
-    BAN_REMAINING=$(f2b_secs_to_hours_minutes_seconds "$BAN_REMAINING")
+    BAN_REMAINING=$(f2b_secs_to_hours_minutes_seconds "$BAN_REMAINING_SECS")
 
     # Get the length of the ban number
     local BAN_NO_LENGTH=${#BAN_NO}

--- a/f2b
+++ b/f2b
@@ -226,7 +226,7 @@ f2b_jail_exists() {
 # Usage: f2b_secs_to_hours_minutes_seconds <seconds>
 # Example: f2b_secs_to_hours_minutes_seconds 3600 (01:00:00)
 # Example: f2b_secs_to_hours_minutes_seconds 3661 (01:01:01)
-# Returns: hours:minutes:seconds
+# Returns: hours:minutes:seconds (hours can exceed 24)
 f2b_secs_to_hours_minutes_seconds() {
   local SECONDS=${1:-0}
 
@@ -240,7 +240,6 @@ f2b_secs_to_hours_minutes_seconds() {
     exit 1
   fi
 
-  local SECONDS=$((SECONDS % 86400))
   local HOURS=$((SECONDS / 3600))
   local SECONDS=$((SECONDS % 3600))
   local MINUTES=$((SECONDS / 60))
@@ -442,7 +441,7 @@ f2b_banned_ips() {
   local R2W=4  # Jail, sshd might be the most common
   local R3W=15 # IP Address, 3+1+3+1+3+1+3=15 (xxx.xxx.xxx)
   local R4W=19 # Banned Date, 10+1+8=19 (YYYY-MM-DD HH:MM:SS)
-  local R5W=8  # Ban Expires, 2+1+2+1+2=8 (HH:MM:SS)
+  local R5W=8  # Ban Expires, 2+1+2+1+2=8 (HH:MM:SS, hours may exceed 24)
 
   # Use BANNED_IPS to loop through the banned IPs and get values for the upcoming table
   # The table will have the following columns:
@@ -483,6 +482,9 @@ f2b_banned_ips() {
     BAN_EXPIRES_SECS=$(date -d "$BAN_EXPIRES" +%s)
     # Calculate the time remaining until the IP is unbanned
     local BAN_REMAINING_SECS=$((BAN_EXPIRES_SECS - CURRENT_TIME))
+    if [ "$BAN_REMAINING_SECS" -lt 0 ]; then
+      BAN_REMAINING_SECS=0
+    fi
 
     # Format the time remaining until the IP is unbanned
     local BAN_REMAINING=""
@@ -560,7 +562,8 @@ f2b_banned_ips() {
   printf "+-%-${R1W}s-+-%-${R2W}s-+-%-${R3W}s-+-%-${R4W}s-+-%-${R5W}s-+\n" \
     "" "" "" "" ""
   echo ""
-  echo "Expiration time is in days:hours:minutes format."
+  echo "Expiration time is in hours:minutes:seconds format."
+  echo "Hours may exceed 24."
   echo ""
 }
 

--- a/f2b
+++ b/f2b
@@ -222,11 +222,11 @@ f2b_jail_exists() {
   exit 1
 }
 
-# Convert seconds to hours, minutes, and seconds
+# Convert seconds to days, hours, minutes, and seconds
 # Usage: f2b_secs_to_hours_minutes_seconds <seconds>
-# Example: f2b_secs_to_hours_minutes_seconds 3600 (01:00:00)
-# Example: f2b_secs_to_hours_minutes_seconds 3661 (01:01:01)
-# Returns: hours:minutes:seconds (hours can exceed 24)
+# Example: f2b_secs_to_hours_minutes_seconds 3600 (00:01:00:00)
+# Example: f2b_secs_to_hours_minutes_seconds 90061 (01:01:01:01)
+# Returns: days:hours:minutes:seconds
 f2b_secs_to_hours_minutes_seconds() {
   local SECONDS=${1:-0}
 
@@ -240,13 +240,15 @@ f2b_secs_to_hours_minutes_seconds() {
     exit 1
   fi
 
+  local DAYS=$((SECONDS / 86400))
+  SECONDS=$((SECONDS % 86400))
   local HOURS=$((SECONDS / 3600))
-  local SECONDS=$((SECONDS % 3600))
+  SECONDS=$((SECONDS % 3600))
   local MINUTES=$((SECONDS / 60))
-  local SECONDS=$((SECONDS % 60))
+  SECONDS=$((SECONDS % 60))
 
-  # Pad hours, minutes, and seconds with zeros if they are less than 10
-  echo "$(printf "%02d" "$HOURS"):$(printf "%02d" "$MINUTES"):$(printf "%02d" "$SECONDS")"
+  # Pad all components with zeros if needed
+  echo "$(printf "%02d" "$DAYS"):$(printf "%02d" "$HOURS"):$(printf "%02d" "$MINUTES"):$(printf "%02d" "$SECONDS")"
 }
 
 # Ban IP address in a specific jail, if provided
@@ -441,7 +443,7 @@ f2b_banned_ips() {
   local R2W=4  # Jail, sshd might be the most common
   local R3W=15 # IP Address, 3+1+3+1+3+1+3=15 (xxx.xxx.xxx)
   local R4W=19 # Banned Date, 10+1+8=19 (YYYY-MM-DD HH:MM:SS)
-  local R5W=8  # Ban Expires, 2+1+2+1+2=8 (HH:MM:SS, hours may exceed 24)
+  local R5W=11 # Ban Expires, 2+1+2+1+2+1+2=11 (DD:HH:MM:SS)
 
   # Use BANNED_IPS to loop through the banned IPs and get values for the upcoming table
   # The table will have the following columns:
@@ -562,8 +564,7 @@ f2b_banned_ips() {
   printf "+-%-${R1W}s-+-%-${R2W}s-+-%-${R3W}s-+-%-${R4W}s-+-%-${R5W}s-+\n" \
     "" "" "" "" ""
   echo ""
-  echo "Expiration time is in hours:minutes:seconds format."
-  echo "Hours may exceed 24."
+  echo "Expiration time is in days:hours:minutes:seconds format."
   echo ""
 }
 

--- a/tests/f2b.bats
+++ b/tests/f2b.bats
@@ -47,3 +47,15 @@ MOCK
   run "$BATS_TEST_DIRNAME/../f2b" logs sshd
   [ "$status" -eq 0 ]
 }
+
+@test "format seconds into DD:HH:MM:SS" {
+  run bash -c "source <(awk '/^f2b_secs_to_hours_minutes_seconds()/,/^}/' '$BATS_TEST_DIRNAME/../f2b'); f2b_secs_to_hours_minutes_seconds 90061"
+  [ "$status" -eq 0 ]
+  [ "$output" = "01:01:01:01" ]
+}
+
+@test "negative seconds returns error" {
+  run bash -c "source <(awk '/^f2b_secs_to_hours_minutes_seconds()/,/^}/' '$BATS_TEST_DIRNAME/../f2b'); f2b_secs_to_hours_minutes_seconds -1"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"positive integer"* ]]
+}


### PR DESCRIPTION
## Summary
- fix computation of remaining ban time

## Testing
- `bats tests/f2b.bats`
- 

Fixes: #2 

------
https://chatgpt.com/codex/tasks/task_e_68638d35e1cc832f9ce41e84c3b7cc0a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ban expiration times now display days, hours, minutes, and seconds for more precise timing information.  
* **Bug Fixes**
  * Negative ban time values are handled gracefully by setting remaining time to zero.  
* **Tests**
  * Added tests to verify accurate conversion of seconds into days, hours, minutes, and seconds format and proper error handling for invalid inputs.  
* **Style**
  * Improved variable naming for clearer display of ban expiration times in the banned IPs list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->