### PR TITLE
chore(gitignore): ignore env and binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.log
 f2b
 coverage.*
+.env*
+*.exe
+*.dll
+.DS_Store


### PR DESCRIPTION
## Summary
- avoid committing local env, binary, and system files by expanding .gitignore

## Testing
- `gofmt -w $(git ls-files '*.go')`
- `goimports -w $(git ls-files '*.go')`


------
https://chatgpt.com/codex/tasks/task_e_686fd07505c8832f861ed4d3a15413c6