### PR TITLE
chore(config): remove indent_size from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,4 @@ indent_size = 2
 
 [*.go]
 indent_style = tab
-indent_size = 4
 indent_width = 2


### PR DESCRIPTION
## Summary
- clean up Go section in `.editorconfig`

## Testing
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run` *(fails: unsupported configuration version)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fd1422384832fa7c83426b53fa1af