### PR TITLE
feat(cli): inject version via ldflags

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,7 +22,8 @@ A modern, secure, and extensible Go CLI tool for managing [Fail2Ban](https://www
 # Clone and build
 git clone https://github.com/ivuorinen/f2b.git
 cd f2b
-go build -o f2b .
+# set version information via ldflags if desired
+go build -ldflags "-X github.com/ivuorinen/f2b/cmd.version=1.2.3" -o f2b .
 
 # Or install globally
 go install github.com/ivuorinen/f2b@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Build
         run: |
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
-            go build -o f2b_${{ matrix.os }}_${{ matrix.arch }} ./...
+            go build -ldflags "-X github.com/ivuorinen/f2b/cmd.version=${{ github.ref_name }}" \
+            -o f2b_${{ matrix.os }}_${{ matrix.arch }} ./...
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4

--- a/FAQ.md
+++ b/FAQ.md
@@ -23,7 +23,7 @@ See the README for full instructions. In short:
 ```bash
 git clone https://github.com/ivuorinen/f2b.git
 cd f2b
-go build -o f2b .
+go build -ldflags "-X github.com/ivuorinen/f2b/cmd.version=1.2.3" -o f2b .
 ```
 
 Or install globally:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -785,7 +785,7 @@ func TestVersionCommand(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expectedOut := "f2b version 1.0.0\n"
+	expectedOut := fmt.Sprintf("f2b version %s\n", version)
 	if output != expectedOut {
 		t.Errorf("expected output %q, got %q", expectedOut, output)
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
+
+// version holds the build version and can be overridden at build time with ldflags
+var version = "dev"
 
 // VersionCmd returns the version command with output consistency
 func VersionCmd(format string) *cobra.Command {
@@ -10,7 +15,7 @@ func VersionCmd(format string) *cobra.Command {
 		Use:   "version",
 		Short: "Show f2b version",
 		Run: func(cmd *cobra.Command, args []string) {
-			PrintOutputTo(GetCmdOutput(cmd), "f2b version 1.0.0", format)
+			PrintOutputTo(GetCmdOutput(cmd), fmt.Sprintf("f2b version %s", version), format)
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- make version string configurable via ldflags
- update tests
- add build flag usage in docs
- pass version through release workflow

## Testing
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run` *(fails: Can't read config: 'Version' expected a map, got 'string')*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686fd1a1242c832fab63258ef97fae92