### PR TITLE
chore(repo): anchor ignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.log
-f2b
+/f2b*
 coverage.*
 .env*
 *.exe


### PR DESCRIPTION
## Summary
- narrow `.gitignore` build artifact pattern

## Testing
- `goimports -w .`
- `gofmt -w .`


------
https://chatgpt.com/codex/tasks/task_e_686fd92f9764832f8bce07f81a527913