### PR TITLE
chore(ci): use golangci-lint action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -25,15 +25,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
       - name: Run go fmt
         run: go fmt ./...
       - name: Run go vet
         run: go vet ./...
       - name: Run golangci-lint
-        run: golangci-lint run
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.2.0
+          args: --timeout=5m
       - name: Run integration tests and collect coverage
         run: |
           go test -coverprofile=coverage.out ./...


### PR DESCRIPTION
## Summary
- use golangci-lint-action in PR workflow
- enforce LF line endings for Go files

## Testing
- `go fmt ./...`
- `goimports -w .`
- *(lint and tests skipped: no Go code changes)*

------
https://chatgpt.com/codex/tasks/task_e_686fd9fe694c832faa990ae28c89b3dd