### PR TITLE
fix(workflows): create single release for matrix uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,20 @@ on:
       - "v*.*.*"
 
 jobs:
-  build-and-release:
+  # Create the release only once. Subsequent jobs upload assets using its URL.
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
+        with:
+          tag_name: ${{ github.ref_name }}
+
+  build-and-upload:
+    needs: release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,15 +36,10 @@ jobs:
         run: |
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
             go build -o f2b_${{ matrix.os }}_${{ matrix.arch }} ./...
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        with:
-          tag_name: ${{ github.ref_name }}
       - name: Upload Asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: f2b_${{ matrix.os }}_${{ matrix.arch }}
           asset_name: f2b_${{ matrix.os }}_${{ matrix.arch }}
           asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- create a single Release job and reference its upload_url for matrix jobs
- clarify workflow with a comment

## Testing
- `golangci-lint run` *(fails: can't load config)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686fd30a33d8832fb2fbd6fd2507a1e9