### PR TITLE
feat(fail2ban): expose GetLogDir

### DIFF
--- a/fail2ban/fail2ban.go
+++ b/fail2ban/fail2ban.go
@@ -28,6 +28,11 @@ var filterDir = "/etc/fail2ban/filter.d"
 func SetLogDir(dir string) {
 	logDir = dir
 }
+
+// GetLogDir returns the current log directory path
+func GetLogDir() string {
+	return logDir
+}
 func SetFilterDir(dir string) {
 	filterDir = dir
 }

--- a/fail2ban/utils_test.go
+++ b/fail2ban/utils_test.go
@@ -14,8 +14,8 @@ import (
 
 // TestSetLogDir tests the log directory setting functionality
 func TestSetLogDir(t *testing.T) {
-	// Save original log directory
-	originalLogDir := "/var/log"
+	// Save original log directory using GetLogDir to avoid test pollution
+	originalLogDir := fail2ban.GetLogDir()
 
 	// Test setting a new log directory
 	testDir := "/tmp/test-logs"


### PR DESCRIPTION
## Summary
- provide GetLogDir helper
- preserve original log directory in TestSetLogDir

## Testing
- `golangci-lint run` *(fails: unsupported configuration version)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fdc92f768832f91659099a45a3b39