### PR TITLE
test(cmd): improve IP mock validation

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -249,8 +250,17 @@ func (m *MockClient) TestFilter(filter string) (string, error) {
 
 // Mock validation functions (simplified versions of the real ones)
 func isValidIPMock(ip string) bool {
-	// Simple validation - just check for basic format
-	return len(ip) > 6 && strings.Contains(ip, ".")
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return false
+		}
+	}
+	return true
 }
 
 func isValidJailMock(jail string) bool {


### PR DESCRIPTION
## Summary
- enhance IP validation logic in tests
- include strconv for conversion

## Testing
- `golangci-lint run` *(fails: unsupported config version)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fdd5fad34832f8a38313762c9f2c7