### PR TITLE
fix(ci): correct args indentation in pr-lint workflow

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -31,7 +31,7 @@ jobs:
         run: go vet ./...
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
-         with:
+        with:
           args: --timeout=5m
       - name: Run integration tests and collect coverage
         run: |


### PR DESCRIPTION
## Summary
- ensure `with:` is aligned under `uses` in pr-lint workflow

## Testing
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`


------
https://chatgpt.com/codex/tasks/task_e_687039ce301c832f9ed79a7e9ff1cbf6