### PR TITLE
fix(ci): avoid duplicate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,19 @@ on:
       - "v*.*.*"
 
 jobs:
-  build-and-release:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
+        with:
+          tag_name: ${{ github.ref_name }}
+
+  build-and-upload:
+    needs: create-release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,15 +36,10 @@ jobs:
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
             go build -ldflags "-X github.com/ivuorinen/f2b/cmd.version=${{ github.ref_name }}" \
             -o f2b_${{ matrix.os }}_${{ matrix.arch }} ./...
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        with:
-          tag_name: ${{ github.ref_name }}
       - name: Upload Asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: f2b_${{ matrix.os }}_${{ matrix.arch }}
           asset_name: f2b_${{ matrix.os }}_${{ matrix.arch }}
           asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- create a single GitHub release outside the matrix
- upload each artifact to that release

## Testing
- `golangci-lint run` *(fails: unsupported version of the configuration)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68703b2208c0832f9b3a7ecafbffeee3