### PR TITLE
refactor(fail2ban): remove test check from OSRunner

### DIFF
--- a/fail2ban/fail2ban.go
+++ b/fail2ban/fail2ban.go
@@ -54,11 +54,6 @@ func (r *OSRunner) CombinedOutput(name string, args ...string) ([]byte, error) {
 
 // CombinedOutputWithSudo executes a command with sudo if needed.
 func (r *OSRunner) CombinedOutputWithSudo(name string, args ...string) ([]byte, error) {
-	// In test environment, prevent real execution by delegating to mock
-	if isTest() {
-		// This should not be called in tests - the mock runner should be used instead
-		return nil, fmt.Errorf("OSRunner should not be used in tests")
-	}
 
 	checker := GetSudoChecker()
 


### PR DESCRIPTION
## Summary
- remove test-only conditional from `CombinedOutputWithSudo`

## Testing
- `golangci-lint run` *(fails: unsupported version of the configuration)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68703a390ad0832f9e41fa9ea1168fd9