### PR TITLE
refactor(fail2ban): make log and filter dirs configurable

### DIFF
--- a/fail2ban/client.go
+++ b/fail2ban/client.go
@@ -36,8 +36,10 @@ type Client interface {
 
 // RealClient is the default implementation of Client, using the local fail2ban-client binary.
 type RealClient struct {
-	Path  string   // Path to fail2ban-client
-	Jails []string // List of available jails
+	Path      string // Path to fail2ban-client
+	Jails     []string
+	LogDir    string
+	FilterDir string
 }
 
 // BanRecord represents a single ban entry with jail, IP, ban time, and remaining duration.
@@ -52,7 +54,7 @@ type BanRecord struct {
 // It checks for fail2ban-client in PATH, ensures the service is running, checks sudo privileges,
 // and loads available jails. Returns an error if fail2ban is not available, not running, or
 // user lacks sudo privileges.
-func NewClient() (*RealClient, error) {
+func NewClient(logDir, filterDir string) (*RealClient, error) {
 	// Check sudo privileges first (skip in test environment unless forced)
 	if !isTest() || os.Getenv("F2B_TEST_SUDO") == "true" {
 		if err := CheckSudoRequirements(); err != nil {
@@ -69,7 +71,14 @@ func NewClient() (*RealClient, error) {
 			return nil, errors.New("fail2ban-client not found in PATH")
 		}
 	}
-	rc := &RealClient{Path: path}
+	if logDir == "" {
+		logDir = DefaultLogDir
+	}
+	if filterDir == "" {
+		filterDir = DefaultFilterDir
+	}
+
+	rc := &RealClient{Path: path, LogDir: logDir, FilterDir: filterDir}
 
 	// Version check - use sudo if needed
 	out, err := RunnerCombinedOutputWithSudo(path, "-V")

--- a/fail2ban/fail2ban.go
+++ b/fail2ban/fail2ban.go
@@ -18,12 +18,14 @@ import (
 const (
 	// DefaultLogDir is the default directory for fail2ban logs
 	DefaultLogDir = "/var/log"
+	// DefaultFilterDir is the default directory for fail2ban filters
+	DefaultFilterDir = "/etc/fail2ban/filter.d"
 	// AllFilter represents all jails/IPs filter
 	AllFilter = "all"
 )
 
 var logDir = DefaultLogDir // base directory for fail2ban logs
-var filterDir = "/etc/fail2ban/filter.d"
+var filterDir = DefaultFilterDir
 
 func SetLogDir(dir string) {
 	logDir = dir
@@ -448,7 +450,7 @@ func formatDuration(sec int64) string {
 }
 
 func (c *RealClient) GetLogLines(jail, ip string) ([]string, error) {
-	pattern := filepath.Join("/var/log", "fail2ban.log*")
+	pattern := filepath.Join(c.LogDir, "fail2ban.log*")
 	files, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, err
@@ -503,7 +505,7 @@ func ListFilters() ([]string, error) {
 }
 
 func (c *RealClient) ListFilters() ([]string, error) {
-	entries, err := os.ReadDir(filterDir)
+	entries, err := os.ReadDir(c.FilterDir)
 	if err != nil {
 		return nil, fmt.Errorf("could not list filters: %v", err)
 	}
@@ -555,7 +557,7 @@ func (c *RealClient) TestFilter(filter string) (string, error) {
 	if !isValidFilter(filter) {
 		return "", fmt.Errorf("invalid filter name")
 	}
-	path := filterDir + "/" + filter + ".conf"
+	path := filepath.Join(c.FilterDir, filter+".conf")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("filter not found: %v", err)

--- a/fail2ban/fail2ban_test.go
+++ b/fail2ban/fail2ban_test.go
@@ -62,7 +62,7 @@ func TestNewClient(t *testing.T) {
 			}
 			SetRunner(mockRunner)
 
-			client, err := NewClient()
+			client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 
 			if tt.expectError {
 				if err == nil {
@@ -145,14 +145,14 @@ func TestListJails(t *testing.T) {
 
 			if tt.expectError {
 				// For error cases, we expect NewClient to fail
-				_, err := NewClient()
+				_, err := NewClient(DefaultLogDir, DefaultFilterDir)
 				if err == nil {
 					t.Fatal("expected error but got none")
 				}
 				return
 			}
 
-			client, err := NewClient()
+			client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
@@ -198,7 +198,7 @@ func TestStatusAll(t *testing.T) {
 
 	SetRunner(mock)
 
-	client, err := NewClient()
+	client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestStatusJail(t *testing.T) {
 
 	SetRunner(mock)
 
-	client, err := NewClient()
+	client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestBanIP(t *testing.T) {
 
 			SetRunner(mock)
 
-			client, err := NewClient()
+			client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
@@ -392,7 +392,7 @@ func TestUnbanIP(t *testing.T) {
 
 			SetRunner(mock)
 
-			client, err := NewClient()
+			client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
@@ -478,7 +478,7 @@ func TestBannedIn(t *testing.T) {
 
 			SetRunner(mock)
 
-			client, err := NewClient()
+			client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}
@@ -537,7 +537,7 @@ func TestGetBanRecords(t *testing.T) {
 
 	SetRunner(mock)
 
-	client, err := NewClient()
+	client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -654,7 +654,7 @@ func TestListFilters(t *testing.T) {
 	mock.SetResponse("fail2ban-client status", []byte("Status\n|- Number of jail: 1\n`- Jail list: sshd"))
 	SetRunner(mock)
 
-	client, err := NewClient()
+	client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -705,7 +705,7 @@ logpath = /var/log/auth.log`
 
 	SetRunner(mock)
 
-	client, err := NewClient()
+	client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -764,7 +764,7 @@ func TestVersionComparison(t *testing.T) {
 			}
 			SetRunner(mock)
 
-			_, err := NewClient()
+			_, err := NewClient(DefaultLogDir, DefaultFilterDir)
 
 			if tt.expectError && err == nil {
 				t.Fatal("expected error but got none")

--- a/fail2ban/integration_sudo_test.go
+++ b/fail2ban/integration_sudo_test.go
@@ -78,7 +78,7 @@ func TestSudoIntegrationWithClient(t *testing.T) {
 			SetRunner(mockRunner)
 
 			// Test client creation
-			client, err := NewClient()
+			client, err := NewClient(DefaultLogDir, DefaultFilterDir)
 
 			if tt.expectClientError {
 				if err == nil {

--- a/fail2ban/utils_test.go
+++ b/fail2ban/utils_test.go
@@ -337,7 +337,7 @@ func TestBanRecordFormatting(t *testing.T) {
 
 	fail2ban.SetRunner(mock)
 
-	client, err := fail2ban.NewClient()
+	client, err := fail2ban.NewClient(fail2ban.DefaultLogDir, fail2ban.DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestVersionComparisonEdgeCases(t *testing.T) {
 			}
 			fail2ban.SetRunner(mock)
 
-			_, err := fail2ban.NewClient()
+			_, err := fail2ban.NewClient(fail2ban.DefaultLogDir, fail2ban.DefaultFilterDir)
 
 			if tt.expectError && err == nil {
 				t.Fatal("expected error but got none")
@@ -501,7 +501,7 @@ func TestClientInitializationEdgeCases(t *testing.T) {
 			tt.setupMock(mock)
 			fail2ban.SetRunner(mock)
 
-			_, err := fail2ban.NewClient()
+			_, err := fail2ban.NewClient(fail2ban.DefaultLogDir, fail2ban.DefaultFilterDir)
 
 			if tt.expectError && err == nil {
 				t.Fatal("expected error but got none")
@@ -530,7 +530,7 @@ func TestConcurrentAccess(t *testing.T) {
 	mock.SetResponse("fail2ban-client banned 192.168.1.100", []byte(`["sshd"]`))
 	fail2ban.SetRunner(mock)
 
-	client, err := fail2ban.NewClient()
+	client, err := fail2ban.NewClient(fail2ban.DefaultLogDir, fail2ban.DefaultFilterDir)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -584,7 +584,7 @@ func TestMemoryUsage(t *testing.T) {
 
 	// Create and destroy many clients
 	for i := 0; i < 1000; i++ {
-		client, err := fail2ban.NewClient()
+		client, err := fail2ban.NewClient(fail2ban.DefaultLogDir, fail2ban.DefaultFilterDir)
 		if err != nil {
 			t.Fatalf("failed to create client: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 
 	if !skip {
-		client, err = fail2ban.NewClient()
+		client, err = fail2ban.NewClient(config.LogDir, config.FilterDir)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			// Check if this is a sudo privilege error
@@ -49,8 +49,6 @@ func main() {
 		// Use a no-op client for skip-only commands to prevent nil-pointer dereferences
 		client = fail2ban.NewNoOpClient()
 	}
-	fail2ban.SetLogDir(config.LogDir)
-	fail2ban.SetFilterDir(config.FilterDir)
 
 	if err := cmd.Execute(client, config); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- make `fail2ban.NewClient` accept log and filter directories
- store directories on `RealClient`
- pass config dirs from `main`
- adjust tests for new constructor

## Testing
- `golangci-lint run` *(fails: unsupported configuration version)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68703aadd3d4832f97ebf3a01994d0af