### PR TITLE
chore(dev): add codex setup script

### DIFF
--- a/codex.sh
+++ b/codex.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install development tooling for the f2b project.
+# This script installs Go-based tools used for linting and formatting.
+set -euo pipefail
+
+# Determine Go environment
+if ! command -v go >/dev/null; then
+  echo "Go is required to install tools" >&2
+  exit 1
+fi
+
+# Install goimports for formatting
+echo "Installing goimports..."
+go install golang.org/x/tools/cmd/goimports@latest
+
+# Install golangci-lint for linting
+echo "Installing golangci-lint..."
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+echo "Tool installation complete."


### PR DESCRIPTION
## Summary
- add `codex.sh` for installing `goimports` and `golangci-lint`

## Testing
- `gofmt -w main.go main_test.go cmd/*.go fail2ban/*.go`
- `goimports -w .`
- `golangci-lint run` *(fails: unsupported configuration version)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6870d1139d94832fa722d4ba8b384371