### PR TITLE
refactor(cmd): centralize env config

### DIFF
--- a/cmd/config_utils.go
+++ b/cmd/config_utils.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "os"
+
+// NewConfigFromEnv builds Config from environment variables with defaults.
+func NewConfigFromEnv() Config {
+	cfg := Config{}
+	cfg.LogDir = os.Getenv("F2B_LOG_DIR")
+	if cfg.LogDir == "" {
+		cfg.LogDir = "/var/log"
+	}
+	cfg.FilterDir = os.Getenv("F2B_FILTER_DIR")
+	if cfg.FilterDir == "" {
+		cfg.FilterDir = "/etc/fail2ban/filter.d"
+	}
+	cfg.Format = "plain"
+	return cfg
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,15 +44,7 @@ func Execute(client fail2ban.Client, config Config) error {
 
 func init() {
 	// Set defaults from env
-	cfg.LogDir = os.Getenv("F2B_LOG_DIR")
-	if cfg.LogDir == "" {
-		cfg.LogDir = "/var/log"
-	}
-	cfg.FilterDir = os.Getenv("F2B_FILTER_DIR")
-	if cfg.FilterDir == "" {
-		cfg.FilterDir = "/etc/fail2ban/filter.d"
-	}
-	cfg.Format = "plain"
+	cfg = NewConfigFromEnv()
 
 	rootCmd.PersistentFlags().StringVar(&cfg.LogDir, "log-dir", cfg.LogDir, "Fail2Ban log directory")
 	rootCmd.PersistentFlags().StringVar(&cfg.FilterDir, "filter-dir", cfg.FilterDir, "Fail2Ban filter directory")

--- a/main.go
+++ b/main.go
@@ -15,16 +15,7 @@ func main() {
 	var err error
 
 	// Build config from env/flags
-	config := cmd.Config{}
-	config.LogDir = os.Getenv("F2B_LOG_DIR")
-	if config.LogDir == "" {
-		config.LogDir = "/var/log"
-	}
-	config.FilterDir = os.Getenv("F2B_FILTER_DIR")
-	if config.FilterDir == "" {
-		config.FilterDir = "/etc/fail2ban/filter.d"
-	}
-	config.Format = "plain"
+	config := cmd.NewConfigFromEnv()
 
 	skip := false
 	if len(args) > 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -539,7 +539,6 @@ func TestMainConfigurationParsing(t *testing.T) {
 			if config.FilterDir == "" {
 				config.FilterDir = "/etc/fail2ban/filter.d"
 			}
-			config.Format = "plain"
 
 			if config.LogDir != tt.expectedLogDir {
 				t.Errorf("expected LogDir=%q, got %q", tt.expectedLogDir, config.LogDir)


### PR DESCRIPTION
## Summary
- remove duplication by adding `NewConfigFromEnv`
- use the helper in `main` and `root` to load defaults
- fix tests for unused field writes

## Testing
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6870ff65c72c832fba4ebe5ba59b060d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified configuration initialization by consolidating environment variable reading and default value assignment into a single function.
* **Tests**
  * Updated tests to align with the new configuration initialization approach, removing explicit assignment of the format field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->