### PR TITLE
chore(dev): add pre-commit config

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -54,6 +54,7 @@ Welcome, AI agents and large language models! This document provides context and
 - Test privilege scenarios: privileged users, unprivileged users, and edge cases.
 - Set `F2B_TEST_SUDO=true` when testing sudo validation behavior.
 - Ensure all tests pass (`go test ./...`) before submitting changes.
+- Run `pre-commit run --all-files` and fix any issues. MegaLinter requires Docker and does not work with Podman.
 
 #### f. Pull Requests
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -294,6 +294,22 @@ go test -coverprofile=coverage.out ./...
 F2B_TEST_SUDO=true go test ./fail2ban -run TestSudo
 ```
 
+### Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to automate linting and formatting.
+Install the hooks after cloning:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+MegaLinter requires Docker and does not currently work with Podman. Run the hooks before committing:
+
+```bash
+pre-commit run --all-files
+```
+
 ### Integration Examples
 
 ```bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/oxsecurity/megalinter
+    rev: v8.4.2 # Git tag specifying the hook, not mega-linter-runner, version
+    hooks:
+      - id: megalinter-incremental # Faster, less thorough
+        stages:
+          - pre-commit
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1
+    hooks:
+      - id: go-build-mod
+        alias: build
+      - id: go-mod-tidy
+        alias: tidy
+      - id: go-fmt
+        alias: fmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Define clear instructions so AI or human contributors keep changes consistent an
 - **Config Verification**: whenever modifying `.golangci.yml` or updating `golangci-lint`, run `golangci-lint config verify` to ensure the configuration remains valid.
 - **Tests**: run `go test ./...` after linting whenever code changes. Skip when editing comments or docs only.
 - **Package Manager**: always use `yarn` if installing npm packages.
+- **Pre-commit**: run `pre-commit run --all-files` and fix every issue before committing. MegaLinter requires Docker and doesn't support Podman.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml`
- document pre-commit setup in README
- require running pre-commit in AGENTS guidelines

## Testing
- `gofmt -w main.go cmd/*/*.go fail2ban/*.go main_test.go`
- `goimports -w .`

------
https://chatgpt.com/codex/tasks/task_e_68711b9b7ec8832f8cba41d144127acd