### PR TITLE
fix(ci): disable cgo in cross compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       - name: Build
         run: |
-          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
+          CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
             go build -ldflags "-X github.com/ivuorinen/f2b/cmd.version=${{ github.ref_name }}" \
             -o f2b_${{ matrix.os }}_${{ matrix.arch }} ./...
       - name: Upload Asset


### PR DESCRIPTION
## Summary
- disable CGO when cross-compiling release binaries

## Testing
- `pre-commit run --all-files` *(fails: Docker engine has not been found)*
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68711fbcdeec832f86ce955cfb98a186