### PR TITLE
fix(ci): fail on formatting issues

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -25,8 +25,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Run go fmt
-        run: go fmt ./...
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l $(git ls-files '*.go'))
+          if [ -n "$unformatted" ]; then
+            echo "The following files need formatting:" >&2
+            echo "$unformatted" >&2
+            exit 1
+          fi
       - name: Run go vet
         run: go vet ./...
       - name: Run golangci-lint


### PR DESCRIPTION
## Summary
- prevent `go fmt` from modifying files in CI by running a read-only `gofmt -l` check

## Testing
- `golangci-lint run`
- `go test ./...`
- `pre-commit run --all-files` *(fails: Docker engine has not been found)*

------
https://chatgpt.com/codex/tasks/task_e_68711ff0de88832fad21cf35ba6b6743