### PR TITLE
feat(cmd): add context to logs watch

### DIFF
--- a/cmd/logswatch.go
+++ b/cmd/logswatch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -9,8 +10,9 @@ import (
 )
 
 // LogsWatchCmd returns the logs-watch command with injected client and config
-func LogsWatchCmd(client fail2ban.Client, config *Config) *cobra.Command {
+func LogsWatchCmd(ctx context.Context, client fail2ban.Client, config *Config) *cobra.Command {
 	var limit int
+	var interval time.Duration
 	cmd := &cobra.Command{
 		Use:   "logs-watch [jail] [ip]",
 		Short: "Continuously watch Fail2Ban logs (filtered by jail and/or IP)",
@@ -32,24 +34,34 @@ func LogsWatchCmd(client fail2ban.Client, config *Config) *cobra.Command {
 				prev = prev[len(prev)-limit:]
 			}
 			PrintOutput(strings.Join(prev, "\n"), config.Format)
+			if interval <= 0 {
+				interval = 5 * time.Second
+			}
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
 			for {
-				time.Sleep(5 * time.Second)
-				curr, err := client.GetLogLines(jail, ip)
-				if err != nil {
-					PrintError(err)
-					return err
-				}
-				if limit > 0 && len(curr) > limit {
-					curr = curr[len(curr)-limit:]
-				}
-				if !equal(prev, curr) {
-					PrintOutput(strings.Join(curr, "\n"), config.Format)
-					prev = curr
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-ticker.C:
+					curr, err := client.GetLogLines(jail, ip)
+					if err != nil {
+						PrintError(err)
+						return err
+					}
+					if limit > 0 && len(curr) > limit {
+						curr = curr[len(curr)-limit:]
+					}
+					if !equal(prev, curr) {
+						PrintOutput(strings.Join(curr, "\n"), config.Format)
+						prev = curr
+					}
 				}
 			}
 		},
 	}
 	cmd.Flags().IntVarP(&limit, "limit", "n", 10, "Number of log lines to show/tail")
+	cmd.Flags().DurationVarP(&interval, "interval", "i", 5*time.Second, "Polling interval for checking new logs")
 	return cmd
 }
 

--- a/cmd/logswatch_test.go
+++ b/cmd/logswatch_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -68,7 +69,7 @@ func TestLogsWatchCmd(t *testing.T) {
 			}
 
 			config := &Config{Format: "plain"}
-			cmd := LogsWatchCmd(mock, config)
+			cmd := LogsWatchCmd(context.Background(), mock, config)
 
 			// Set up command flags
 			if tt.limit > 0 {
@@ -117,7 +118,7 @@ func TestLogsWatchCmdJSON(t *testing.T) {
 	}
 
 	config := &Config{Format: JSONFormat}
-	cmd := LogsWatchCmd(mock, config)
+	cmd := LogsWatchCmd(context.Background(), mock, config)
 
 	var outBuf bytes.Buffer
 	cmd.SetOut(&outBuf)
@@ -147,7 +148,7 @@ func TestLogsWatchCmdLimit(t *testing.T) {
 	}
 
 	config := &Config{Format: "plain"}
-	cmd := LogsWatchCmd(mock, config)
+	cmd := LogsWatchCmd(context.Background(), mock, config)
 
 	// Set limit flag
 	if err := cmd.Flags().Set("limit", "3"); err != nil {
@@ -240,7 +241,7 @@ func TestLogsWatchCmdFlags(t *testing.T) {
 	}
 
 	config := &Config{Format: "plain"}
-	cmd := LogsWatchCmd(mock, config)
+	cmd := LogsWatchCmd(context.Background(), mock, config)
 
 	// Test that the limit flag is properly defined
 	limitFlag := cmd.Flags().Lookup("limit")
@@ -254,6 +255,18 @@ func TestLogsWatchCmdFlags(t *testing.T) {
 
 	if limitFlag.DefValue != "10" {
 		t.Errorf("expected limit flag default value to be '10', got %q", limitFlag.DefValue)
+	}
+
+	// Test that the interval flag is properly defined
+	intervalFlag := cmd.Flags().Lookup("interval")
+	if intervalFlag == nil {
+		t.Fatal("interval flag should be defined")
+	}
+	if intervalFlag.Shorthand != "i" {
+		t.Errorf("expected interval flag shorthand to be 'i', got %q", intervalFlag.Shorthand)
+	}
+	if intervalFlag.DefValue != "5s" {
+		t.Errorf("expected interval flag default value to be '5s', got %q", intervalFlag.DefValue)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -27,6 +28,7 @@ var (
 
 func Execute(client fail2ban.Client, config Config) error {
 	cfg = config
+	ctx := context.Background()
 	rootCmd.AddCommand(ListJailsCmd(client))
 	rootCmd.AddCommand(StatusCmd(client, &cfg))
 	rootCmd.AddCommand(BannedCmd(client, cfg.Format))
@@ -34,7 +36,7 @@ func Execute(client fail2ban.Client, config Config) error {
 	rootCmd.AddCommand(UnbanCmd(client, &cfg))
 	rootCmd.AddCommand(TestIPCmd(client, cfg.Format))
 	rootCmd.AddCommand(LogsCmd(client, &cfg))
-	rootCmd.AddCommand(LogsWatchCmd(client, &cfg))
+	rootCmd.AddCommand(LogsWatchCmd(ctx, client, &cfg))
 	rootCmd.AddCommand(ServiceCmd(&cfg))
 	rootCmd.AddCommand(VersionCmd(cfg.Format))
 	rootCmd.AddCommand(TestFilterCmd(client, &cfg))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -516,7 +517,7 @@ func TestCompletionCmdExecution(t *testing.T) {
 			testRoot.AddCommand(UnbanCmd(mockClient, &testConfig))
 			testRoot.AddCommand(TestIPCmd(mockClient, testConfig.Format))
 			testRoot.AddCommand(LogsCmd(mockClient, &testConfig))
-			testRoot.AddCommand(LogsWatchCmd(mockClient, &testConfig))
+			testRoot.AddCommand(LogsWatchCmd(context.Background(), mockClient, &testConfig))
 			testRoot.AddCommand(ServiceCmd(&testConfig))
 			testRoot.AddCommand(VersionCmd(testConfig.Format))
 			testRoot.AddCommand(TestFilterCmd(mockClient, &testConfig))


### PR DESCRIPTION
## Summary
- add context and interval flag for logs-watch command
- pass context from root command
- update unit tests for new signature

## Testing
- `golangci-lint run`
- `go test ./...`
- `pre-commit run --all-files` *(fails: Docker missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871212b2af0832fad69ff1b9266944b