### PR TITLE
test: clear remaining SonarCloud S3776 in tests; drop MegaLinter table-formatter

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -25,6 +25,7 @@ DISABLE_LINTERS:
   - GO_GOLANGCI_LINT # stuck in go version 1.24
   - JSON_V8R # not needed
   - YAML_V8R # not needed
+  - MARKDOWN_MARKDOWN_TABLE_FORMATTER # conflicts with mdformat's table style
 
 ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
   - GITHUB_TOKEN

--- a/cmd/command_test_framework_test.go
+++ b/cmd/command_test_framework_test.go
@@ -480,25 +480,31 @@ func (result *CommandTestResult) AssertJSONField(fieldPath, expected string) *Co
 			result.failMissingJSONField(fieldName, " in output")
 		}
 	case []any:
-		// Handle array case - look in first element
-		if len(v) > 0 {
-			if firstItem, ok := v[0].(map[string]any); ok {
-				if val, ok := firstItem[fieldName]; ok {
-					result.checkJSONFieldValue(val, fieldName, expected)
-				} else {
-					result.failMissingJSONField(fieldName, " in first array element")
-				}
-			} else {
-				result.t.Fatalf("%s: first array element is not an object in output: %s", result.name, result.Output)
-			}
-		} else {
-			result.t.Fatalf("%s: JSON array is empty in output: %s", result.name, result.Output)
-		}
+		result.assertJSONArrayField(v, fieldName, expected)
 	default:
 		result.t.Fatalf("%s: expected JSON object or array but got %T in output: %s", result.name, data, result.Output)
 	}
 
 	return result
+}
+
+// assertJSONArrayField validates fieldName in the first element of a JSON array.
+func (result *CommandTestResult) assertJSONArrayField(arr []any, fieldName, expected string) {
+	result.t.Helper()
+	if len(arr) == 0 {
+		result.t.Fatalf("%s: JSON array is empty in output: %s", result.name, result.Output)
+		return
+	}
+	firstItem, ok := arr[0].(map[string]any)
+	if !ok {
+		result.t.Fatalf("%s: first array element is not an object in output: %s", result.name, result.Output)
+		return
+	}
+	if val, ok := firstItem[fieldName]; ok {
+		result.checkJSONFieldValue(val, fieldName, expected)
+	} else {
+		result.failMissingJSONField(fieldName, " in first array element")
+	}
 }
 
 // AssertEmpty validates that output is empty

--- a/fail2ban/fail2ban_logs_parsing_test.go
+++ b/fail2ban/fail2ban_logs_parsing_test.go
@@ -118,23 +118,30 @@ func TestParseLogLineWithRealData(t *testing.T) {
 			// Exercise the PRODUCTION filter path (passesFilters / containsIPToken),
 			// not just the test-local extractors above — this is what GetLogLines
 			// actually uses to decide whether a line matches a jail/IP query.
-			if tt.wantJail != "" {
-				if !passesFilters(tt.line, LogReadConfig{JailFilter: tt.wantJail}) {
-					t.Errorf("passesFilters(jail=%q) = false, want true for line %q", tt.wantJail, tt.line)
-				}
-				if passesFilters(tt.line, LogReadConfig{JailFilter: "no-such-jail"}) {
-					t.Errorf("passesFilters(jail=no-such-jail) = true, want false for line %q", tt.line)
-				}
-			}
-			if tt.wantIP != "" {
-				if !containsIPToken(tt.line, tt.wantIP) {
-					t.Errorf("containsIPToken(%q) = false, want true for line %q", tt.wantIP, tt.line)
-				}
-				if containsIPToken(tt.line, "203.0.113.255") {
-					t.Errorf("containsIPToken(absent IP) = true, want false for line %q", tt.line)
-				}
-			}
+			assertProductionFilterPath(t, tt.line, tt.wantJail, tt.wantIP)
 		})
+	}
+}
+
+// assertProductionFilterPath checks that the production filter predicates
+// (passesFilters / containsIPToken) match and reject as expected for a line.
+func assertProductionFilterPath(t *testing.T, line, wantJail, wantIP string) {
+	t.Helper()
+	if wantJail != "" {
+		if !passesFilters(line, LogReadConfig{JailFilter: wantJail}) {
+			t.Errorf("passesFilters(jail=%q) = false, want true for line %q", wantJail, line)
+		}
+		if passesFilters(line, LogReadConfig{JailFilter: "no-such-jail"}) {
+			t.Errorf("passesFilters(jail=no-such-jail) = true, want false for line %q", line)
+		}
+	}
+	if wantIP != "" {
+		if !containsIPToken(line, wantIP) {
+			t.Errorf("containsIPToken(%q) = false, want true for line %q", wantIP, line)
+		}
+		if containsIPToken(line, "203.0.113.255") {
+			t.Errorf("containsIPToken(absent IP) = true, want false for line %q", line)
+		}
 	}
 }
 
@@ -489,54 +496,56 @@ func isNumeric(s string) bool {
 // oldest rotated lines and drop the newest when MaxLines trims.
 func TestParseLogFilesOrdering(t *testing.T) {
 	t.Run("numbered scheme", func(t *testing.T) {
-		current, rotated := parseLogFiles([]string{
-			"/var/log/fail2ban.log.1",
+		assertRotatedOrder(t,
+			[]string{
+				"/var/log/fail2ban.log.1",
+				"/var/log/fail2ban.log",
+				"/var/log/fail2ban.log.3.gz",
+				"/var/log/fail2ban.log.2.gz",
+			},
 			"/var/log/fail2ban.log",
-			"/var/log/fail2ban.log.3.gz",
-			"/var/log/fail2ban.log.2.gz",
-		})
-		if current != "/var/log/fail2ban.log" {
-			t.Fatalf("current = %q", current)
-		}
-		want := []string{
-			"/var/log/fail2ban.log.3.gz",
-			"/var/log/fail2ban.log.2.gz",
-			"/var/log/fail2ban.log.1",
-		}
-		if len(rotated) != len(want) {
-			t.Fatalf("rotated = %d files, want %d", len(rotated), len(want))
-		}
-		for i, r := range rotated {
-			if r.path != want[i] {
-				t.Errorf("rotated[%d] = %q, want %q", i, r.path, want[i])
-			}
-		}
+			[]string{
+				"/var/log/fail2ban.log.3.gz",
+				"/var/log/fail2ban.log.2.gz",
+				"/var/log/fail2ban.log.1",
+			},
+		)
 	})
 
 	t.Run("dateext scheme oldest first", func(t *testing.T) {
-		current, rotated := parseLogFiles([]string{
-			"/var/log/fail2ban.log-20240301",
+		assertRotatedOrder(t,
+			[]string{
+				"/var/log/fail2ban.log-20240301",
+				"/var/log/fail2ban.log",
+				"/var/log/fail2ban.log-20240101.gz",
+				"/var/log/fail2ban.log-20240201",
+			},
 			"/var/log/fail2ban.log",
-			"/var/log/fail2ban.log-20240101.gz",
-			"/var/log/fail2ban.log-20240201",
-		})
-		if current != "/var/log/fail2ban.log" {
-			t.Fatalf("current = %q", current)
-		}
-		want := []string{
-			"/var/log/fail2ban.log-20240101.gz",
-			"/var/log/fail2ban.log-20240201",
-			"/var/log/fail2ban.log-20240301",
-		}
-		if len(rotated) != len(want) {
-			t.Fatalf("rotated = %d files, want %d", len(rotated), len(want))
-		}
-		for i, r := range rotated {
-			if r.path != want[i] {
-				t.Errorf("rotated[%d] = %q, want %q", i, r.path, want[i])
-			}
-		}
+			[]string{
+				"/var/log/fail2ban.log-20240101.gz",
+				"/var/log/fail2ban.log-20240201",
+				"/var/log/fail2ban.log-20240301",
+			},
+		)
 	})
+}
+
+// assertRotatedOrder checks parseLogFiles returns the expected current log and
+// rotated ordering (oldest-first) for the given file set.
+func assertRotatedOrder(t *testing.T, files []string, wantCurrent string, wantRotated []string) {
+	t.Helper()
+	current, rotated := parseLogFiles(files)
+	if current != wantCurrent {
+		t.Fatalf("current = %q, want %q", current, wantCurrent)
+	}
+	if len(rotated) != len(wantRotated) {
+		t.Fatalf("rotated = %d files, want %d", len(rotated), len(wantRotated))
+	}
+	for i, r := range rotated {
+		if r.path != wantRotated[i] {
+			t.Errorf("rotated[%d] = %q, want %q", i, r.path, wantRotated[i])
+		}
+	}
 }
 
 // TestContainsIPToken covers whole-token matching including IPv4-mapped IPv6

--- a/main_security_test.go
+++ b/main_security_test.go
@@ -189,78 +189,87 @@ func TestSecurityAudit_PathSecurity(t *testing.T) {
 	defer fail2ban.SetLogDir(originalLogDir)
 
 	t.Run("PathTraversalProtection", func(t *testing.T) {
-		// Every payload is driven through the real validation boundary
-		// (ValidateLogPath, the gate all log reads pass through) and must be
-		// rejected. Payloads that only encode traversal for other stacks
-		// (Windows backslashes, exotic encodings) may survive validation as
-		// literal file names — for those, the resolved path must still stay
-		// inside the log directory and never surface /etc/passwd content.
-		pathTraversalAttempts := []string{
-			"../../../etc/passwd",
-			"..%252f..%252f..%252fetc%252fpasswd",
-			"...//...//etc/passwd",
-			"..;/..;/etc/passwd",
-			"..%00/etc/passwd",
-			"logs/../../../etc/passwd",
-			"logs%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd",
-			"%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd",
-		}
-
-		for _, maliciousPath := range pathTraversalAttempts {
-			resolved, err := fail2ban.ValidateLogPath(context.Background(), maliciousPath, tempDir)
-			if err == nil {
-				t.Errorf("traversal payload %q was accepted, resolved to %q", maliciousPath, resolved)
-			}
-		}
-
-		// End-to-end: with a traversal-named file planted next to the real
-		// log, a full read must return only the legitimate log content.
-		testFile := filepath.Join(tempDir, "test.log")
-		if err := os.WriteFile(testFile, []byte("legit"), 0600); err != nil {
-			t.Fatalf("writing fixture: %v", err)
-		}
-		lines, err := fail2ban.GetLogLines(context.Background(), "all", "all")
-		if err != nil {
-			t.Fatalf("GetLogLines failed: %v", err)
-		}
-		for _, line := range lines {
-			if strings.Contains(line, "root:") {
-				t.Fatalf("log read leaked passwd-like content: %q", line)
-			}
-		}
+		assertPathTraversalRejected(t, tempDir)
 	})
-
 	t.Run("FileOperationSecurity", func(t *testing.T) {
-		// Test that file operations are secure
-		testCases := []struct {
-			name     string
-			testFunc func() error
-		}{
-			{
-				name: "LogFileReading",
-				testFunc: func() error {
-					// Create legitimate log file
-					logFile := filepath.Join(tempDir, "fail2ban.log")
-					content := "2024-01-01 12:00:00,123 fail2ban.actions [1234]: NOTICE [sshd] Ban 192.168.1.100\n"
-					if err := os.WriteFile(logFile, []byte(content), 0600); err != nil {
-						return err
-					}
-
-					_, err := fail2ban.GetLogLines(context.Background(), "sshd", "192.168.1.100")
-					return err
-				},
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				err := tc.testFunc()
-				if err != nil {
-					t.Errorf("Secure operation failed: %v", err)
-				}
-			})
-		}
+		assertFileOperationSecurity(t, tempDir)
 	})
+}
+
+// assertPathTraversalRejected drives traversal payloads through ValidateLogPath
+// (all must be rejected) and verifies an end-to-end read never surfaces
+// passwd-like content even when a traversal-named file sits beside the real log.
+func assertPathTraversalRejected(t *testing.T, tempDir string) {
+	t.Helper()
+	// Payloads that only encode traversal for other stacks (Windows
+	// backslashes, exotic encodings) may survive validation as literal file
+	// names — for those, the resolved path must still stay inside the log
+	// directory and never surface /etc/passwd content.
+	pathTraversalAttempts := []string{
+		"../../../etc/passwd",
+		"..%252f..%252f..%252fetc%252fpasswd",
+		"...//...//etc/passwd",
+		"..;/..;/etc/passwd",
+		"..%00/etc/passwd",
+		"logs/../../../etc/passwd",
+		"logs%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+		"%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+	}
+
+	for _, maliciousPath := range pathTraversalAttempts {
+		resolved, err := fail2ban.ValidateLogPath(context.Background(), maliciousPath, tempDir)
+		if err == nil {
+			t.Errorf("traversal payload %q was accepted, resolved to %q", maliciousPath, resolved)
+		}
+	}
+
+	// End-to-end: with a traversal-named file planted next to the real log, a
+	// full read must return only the legitimate log content.
+	testFile := filepath.Join(tempDir, "test.log")
+	if err := os.WriteFile(testFile, []byte("legit"), 0600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	lines, err := fail2ban.GetLogLines(context.Background(), "all", "all")
+	if err != nil {
+		t.Fatalf("GetLogLines failed: %v", err)
+	}
+	for _, line := range lines {
+		if strings.Contains(line, "root:") {
+			t.Fatalf("log read leaked passwd-like content: %q", line)
+		}
+	}
+}
+
+// assertFileOperationSecurity verifies that legitimate file operations succeed.
+func assertFileOperationSecurity(t *testing.T, tempDir string) {
+	t.Helper()
+	testCases := []struct {
+		name     string
+		testFunc func() error
+	}{
+		{
+			name: "LogFileReading",
+			testFunc: func() error {
+				// Create legitimate log file
+				logFile := filepath.Join(tempDir, "fail2ban.log")
+				content := "2024-01-01 12:00:00,123 fail2ban.actions [1234]: NOTICE [sshd] Ban 192.168.1.100\n"
+				if err := os.WriteFile(logFile, []byte(content), 0600); err != nil {
+					return err
+				}
+
+				_, err := fail2ban.GetLogLines(context.Background(), "sshd", "192.168.1.100")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.testFunc(); err != nil {
+				t.Errorf("Secure operation failed: %v", err)
+			}
+		})
+	}
 }
 
 // TestSecurityAudit_ErrorMessages audits error messages for information leakage


### PR DESCRIPTION
## Summary

Follow-up to #189. Clears the 4 remaining SonarCloud `go:S3776` (cognitive complexity) findings — all on test files — and removes a markdown-formatter conflict in MegaLinter.

## Test complexity (S3776)

Each fix extracts branchy subtest/assertion logic into a named helper — **no behavior change**, verified by the existing suite. `gocognit` reproduced Sonar's numbers exactly for these, so it's used to confirm each drops below the threshold.

| Function | Was | Refactor |
| --- | --- | --- |
| `TestParseLogLineWithRealData` | 23 | → `assertProductionFilterPath` |
| `TestParseLogFilesOrdering` | 18 | → `assertRotatedOrder` |
| `TestSecurityAudit_PathSecurity` | 23 | → `assertPathTraversalRejected` + `assertFileOperationSecurity` |
| `CommandTestResult.AssertJSONField` | 17 | → `assertJSONArrayField` |

## MegaLinter

Disabled `MARKDOWN_MARKDOWN_TABLE_FORMATTER` — its compact table style conflicts with `mdformat` (the repo's markdown formatter), which produced spurious reformat diffs (e.g. on `docs/api.md`). `mdformat` remains the single source of truth for markdown tables.

## Verification

- `go build ./...`, `go test ./...` — pass
- `golangci-lint run` — **0 issues** (the `gocognit: 15` gate added in #189 excludes `*_test.go`, so this refactor is about the SonarCloud finding, not the local gate)
- Pre-commit hooks green (golangci-lint, yamlfmt, editorconfig)

## Note

Only the 4 functions reported on #189 are addressed here. `main`'s full-project dashboard may show a few additional pre-existing `S3776` test functions (e.g. `TestSecurityAudit_ErrorMessages`, `TestParseBanRecordsFromRealLogs`) that were never part of a PR diff — say the word if you'd like those swept up too.
