### PR TITLE
test: sweep remaining SonarCloud S3776 test-complexity (26 functions)

### DIFF
--- a/cmd/cmd_commands_test.go
+++ b/cmd/cmd_commands_test.go
@@ -123,31 +123,39 @@ func TestStatusCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewCommandTest(t, "status").
-				WithArgs(tt.args...).
-				WithSetup(func(mock *fail2ban.MockClient) {
-					setMockJails(mock, tt.jails)
-					if tt.statusAll != "" {
-						mock.StatusAllData = tt.statusAll
-					}
-					if tt.statusJail != nil {
-						mock.StatusJailData = tt.statusJail
-					}
-				})
-
-			if tt.wantError {
-				builder.ExpectError()
-			} else {
-				builder.ExpectSuccess()
-			}
-
-			if tt.wantOutput != "" {
-				builder.ExpectOutput(tt.wantOutput)
-			}
-
-			builder.Run()
+			assertStatusCommandCase(t, tt.args, tt.jails, tt.statusAll,
+				tt.statusJail, tt.wantOutput, tt.wantError)
 		})
 	}
+}
+
+// assertStatusCommandCase runs a single TestStatusCommand table case.
+func assertStatusCommandCase(t *testing.T, args, jails []string, statusAll string,
+	statusJail map[string]string, wantOutput string, wantError bool) {
+	t.Helper()
+	builder := NewCommandTest(t, "status").
+		WithArgs(args...).
+		WithSetup(func(mock *fail2ban.MockClient) {
+			setMockJails(mock, jails)
+			if statusAll != "" {
+				mock.StatusAllData = statusAll
+			}
+			if statusJail != nil {
+				mock.StatusJailData = statusJail
+			}
+		})
+
+	if wantError {
+		builder.ExpectError()
+	} else {
+		builder.ExpectSuccess()
+	}
+
+	if wantOutput != "" {
+		builder.ExpectOutput(wantOutput)
+	}
+
+	builder.Run()
 }
 
 func TestBannedCommand(t *testing.T) {

--- a/cmd/cmd_logswatch_test.go
+++ b/cmd/cmd_logswatch_test.go
@@ -67,50 +67,64 @@ func TestLogsWatchCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a mock client that will return different logs on subsequent calls
-			mock := &MockLogsWatchClient{
-				initialLogs: tt.mockLogs,
-				limit:       tt.limit,
-				shouldError: tt.wantError,
-			}
-
-			config := &Config{Format: "plain"}
-			cmd := LogsWatchCmd(context.Background(), mock, config)
-
-			// Set up command flags
-			if tt.limit > 0 {
-				if err := cmd.Flags().Set("limit", strconv.Itoa(tt.limit)); err != nil {
-					t.Fatalf("failed to set limit flag: %v", err)
-				}
-			}
-
-			// Capture output
-			var outBuf bytes.Buffer
-			cmd.SetOut(&outBuf)
-			cmd.SetArgs(tt.args)
-
-			// For error cases, run the command and check error immediately
-			if tt.wantError {
-				err := cmd.Execute()
-				if err == nil {
-					t.Errorf("expected error but got none")
-				}
-				return
-			}
-
-			// Success cases: run the command with an already-canceled context so
-			// it prints the initial (jail/IP-filtered, limit-tailed) lines and
-			// then exits the watch loop at <-ctx.Done() instead of blocking.
-			watchCtx, cancel := context.WithCancel(context.Background())
-			cancel()
-			if err := cmd.ExecuteContext(watchCtx); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			got := strings.TrimRight(outBuf.String(), "\n")
-			if got != tt.wantOutput {
-				t.Errorf("output = %q, want %q", got, tt.wantOutput)
-			}
+			assertLogsWatchCase(t, tt.args, tt.mockLogs, tt.limit, tt.wantOutput, tt.wantError)
 		})
+	}
+}
+
+// assertLogsWatchCase builds a LogsWatchCmd around a mock client and verifies
+// its output (success) or that it errors (wantError) for a single case.
+func assertLogsWatchCase(
+	t *testing.T,
+	args, mockLogs []string,
+	limit int,
+	wantOutput string,
+	wantError bool,
+) {
+	t.Helper()
+
+	// Create a mock client that will return different logs on subsequent calls
+	mock := &MockLogsWatchClient{
+		initialLogs: mockLogs,
+		limit:       limit,
+		shouldError: wantError,
+	}
+
+	config := &Config{Format: "plain"}
+	cmd := LogsWatchCmd(context.Background(), mock, config)
+
+	// Set up command flags
+	if limit > 0 {
+		if err := cmd.Flags().Set("limit", strconv.Itoa(limit)); err != nil {
+			t.Fatalf("failed to set limit flag: %v", err)
+		}
+	}
+
+	// Capture output
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetArgs(args)
+
+	// For error cases, run the command and check error immediately
+	if wantError {
+		err := cmd.Execute()
+		if err == nil {
+			t.Errorf("expected error but got none")
+		}
+		return
+	}
+
+	// Success cases: run the command with an already-canceled context so
+	// it prints the initial (jail/IP-filtered, limit-tailed) lines and
+	// then exits the watch loop at <-ctx.Done() instead of blocking.
+	watchCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := cmd.ExecuteContext(watchCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimRight(outBuf.String(), "\n")
+	if got != wantOutput {
+		t.Errorf("output = %q, want %q", got, wantOutput)
 	}
 }
 
@@ -317,29 +331,26 @@ func (m *MockLogsWatchClient) GetLogLines(jail, ip string) ([]string, error) {
 		logs = append(logs, fmt.Sprintf("new log line %d", m.callCount))
 	}
 
-	// Apply jail filtering if specified
-	if jail != "" && jail != "all" {
-		var filtered []string
-		for _, line := range logs {
-			if strings.Contains(line, "["+jail+"]") {
-				filtered = append(filtered, line)
-			}
-		}
-		logs = filtered
-	}
-
-	// Apply IP filtering if specified
-	if ip != "" && ip != "all" {
-		var filtered []string
-		for _, line := range logs {
-			if strings.Contains(line, ip) {
-				filtered = append(filtered, line)
-			}
-		}
-		logs = filtered
-	}
+	// Apply jail then IP filtering if specified
+	logs = mockGetLogLinesFiltered(logs, jail, "["+jail+"]")
+	logs = mockGetLogLinesFiltered(logs, ip, ip)
 
 	return logs, nil
+}
+
+// mockGetLogLinesFiltered returns logs unchanged when value is empty or "all",
+// otherwise keeps only lines containing substr.
+func mockGetLogLinesFiltered(logs []string, value, substr string) []string {
+	if value == "" || value == "all" {
+		return logs
+	}
+	var filtered []string
+	for _, line := range logs {
+		if strings.Contains(line, substr) {
+			filtered = append(filtered, line)
+		}
+	}
+	return filtered
 }
 
 // Implement other required methods for the interface

--- a/cmd/cmd_output_test.go
+++ b/cmd/cmd_output_test.go
@@ -159,47 +159,55 @@ func TestPrintError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Capture stderr
-			oldStderr := os.Stderr
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("failed to create pipe: %v", err)
-			}
-			os.Stderr = w
-
-			// Capture log output
-			oldOutput := Logger.Output()
-			var logBuf bytes.Buffer
-			Logger.SetOutput(&logBuf)
-
-			PrintError(tt.err)
-
-			if err := w.Close(); err != nil {
-				t.Fatalf("failed to close pipe writer: %v", err)
-			}
-			os.Stderr = oldStderr
-			Logger.SetOutput(oldOutput)
-
-			var stderrBuf bytes.Buffer
-			if _, err := stderrBuf.ReadFrom(r); err != nil {
-				t.Fatalf("failed to read stderr: %v", err)
-			}
-			stderrOutput := stderrBuf.String()
-			logOutput := logBuf.String()
-
-			if tt.expectLog {
-				if !strings.Contains(logOutput, "Command failed") {
-					t.Errorf("expected error to be logged, got: %s", logOutput)
-				}
-				if !strings.Contains(stderrOutput, "Error: test error message") {
-					t.Errorf("expected error in stderr, got: %s", stderrOutput)
-				}
-			} else {
-				if stderrOutput != "" {
-					t.Errorf("expected no stderr output for nil error, got: %s", stderrOutput)
-				}
-			}
+			assertPrintErrorCase(t, tt.err, tt.expectLog)
 		})
+	}
+}
+
+// assertPrintErrorCase runs PrintError for a single case and verifies the
+// captured stderr and log output against the expectLog expectation.
+func assertPrintErrorCase(t *testing.T, err error, expectLog bool) {
+	t.Helper()
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("failed to create pipe: %v", perr)
+	}
+	os.Stderr = w
+
+	// Capture log output
+	oldOutput := Logger.Output()
+	var logBuf bytes.Buffer
+	Logger.SetOutput(&logBuf)
+
+	PrintError(err)
+
+	if cerr := w.Close(); cerr != nil {
+		t.Fatalf("failed to close pipe writer: %v", cerr)
+	}
+	os.Stderr = oldStderr
+	Logger.SetOutput(oldOutput)
+
+	var stderrBuf bytes.Buffer
+	if _, rerr := stderrBuf.ReadFrom(r); rerr != nil {
+		t.Fatalf("failed to read stderr: %v", rerr)
+	}
+	stderrOutput := stderrBuf.String()
+	logOutput := logBuf.String()
+
+	if expectLog {
+		if !strings.Contains(logOutput, "Command failed") {
+			t.Errorf("expected error to be logged, got: %s", logOutput)
+		}
+		if !strings.Contains(stderrOutput, "Error: test error message") {
+			t.Errorf("expected error in stderr, got: %s", stderrOutput)
+		}
+	} else {
+		if stderrOutput != "" {
+			t.Errorf("expected no stderr output for nil error, got: %s", stderrOutput)
+		}
 	}
 }
 

--- a/cmd/cmd_root_test.go
+++ b/cmd/cmd_root_test.go
@@ -662,46 +662,52 @@ func TestExecuteIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Integration test requires manual approach:
-			// Set up environment variables using t.Setenv for automatic cleanup
-			if tt.config.LogDir != "" {
-				t.Setenv("F2B_LOG_DIR", tt.config.LogDir)
-			}
-			if tt.config.FilterDir != "" {
-				t.Setenv("F2B_FILTER_DIR", tt.config.FilterDir)
-			}
-
-			client := fail2ban.NewMockClient()
-
-			// Capture output
-			oldStdout := os.Stdout
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("failed to create pipe: %v", err)
-			}
-			os.Stdout = w
-
-			originalArgs := os.Args
-			os.Args = tt.args
-
-			err = Execute(client, tt.config)
-
-			// Restore
-			if closeErr := w.Close(); closeErr != nil {
-				t.Fatalf("failed to close writer: %v", closeErr)
-			}
-			os.Stdout = oldStdout
-			os.Args = originalArgs
-
-			// Read output
-			var buf bytes.Buffer
-			if _, readErr := buf.ReadFrom(r); readErr != nil {
-				t.Fatalf("failed to read output: %v", readErr)
-			}
-
-			AssertError(t, err, false, tt.name)
+			assertExecuteIntegrationCase(t, tt.name, tt.args, tt.config)
 		})
 	}
+}
+
+// assertExecuteIntegrationCase runs a single TestExecuteIntegration table case.
+func assertExecuteIntegrationCase(t *testing.T, name string, args []string, config Config) {
+	t.Helper()
+	// Integration test requires manual approach:
+	// Set up environment variables using t.Setenv for automatic cleanup
+	if config.LogDir != "" {
+		t.Setenv("F2B_LOG_DIR", config.LogDir)
+	}
+	if config.FilterDir != "" {
+		t.Setenv("F2B_FILTER_DIR", config.FilterDir)
+	}
+
+	client := fail2ban.NewMockClient()
+
+	// Capture output
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	originalArgs := os.Args
+	os.Args = args
+
+	err = Execute(client, config)
+
+	// Restore
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("failed to close writer: %v", closeErr)
+	}
+	os.Stdout = oldStdout
+	os.Args = originalArgs
+
+	// Read output
+	var buf bytes.Buffer
+	if _, readErr := buf.ReadFrom(r); readErr != nil {
+		t.Fatalf("failed to read output: %v", readErr)
+	}
+
+	AssertError(t, err, false, name)
 }
 
 func TestCompletionCmdWithUnsupportedShell(t *testing.T) {

--- a/cmd/cmd_service_test.go
+++ b/cmd/cmd_service_test.go
@@ -60,32 +60,40 @@ func TestServiceCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewCommandTest(t, "service").
-				WithArgs(tt.args...).
-				WithServiceSetup(func(mock *fail2ban.MockRunner) {
-					if tt.mockResponse != "" {
-						command := "sudo service fail2ban " + strings.Join(tt.args, " ")
-						mock.SetResponse(command, []byte(tt.mockResponse))
-					}
-					if tt.mockError != nil {
-						command := "sudo service fail2ban " + strings.Join(tt.args, " ")
-						mock.SetError(command, tt.mockError)
-					}
-				})
-
-			if tt.wantError {
-				builder.ExpectError()
-			} else {
-				builder.ExpectSuccess()
-			}
-
-			if tt.wantOutput != "" {
-				builder.ExpectOutput(tt.wantOutput)
-			}
-
-			builder.Run()
+			assertServiceCmdCase(t, tt.args, tt.mockResponse, tt.mockError,
+				tt.wantOutput, tt.wantError)
 		})
 	}
+}
+
+// assertServiceCmdCase runs a single TestServiceCmd table case.
+func assertServiceCmdCase(t *testing.T, args []string, mockResponse string,
+	mockError error, wantOutput string, wantError bool) {
+	t.Helper()
+	builder := NewCommandTest(t, "service").
+		WithArgs(args...).
+		WithServiceSetup(func(mock *fail2ban.MockRunner) {
+			if mockResponse != "" {
+				command := "sudo service fail2ban " + strings.Join(args, " ")
+				mock.SetResponse(command, []byte(mockResponse))
+			}
+			if mockError != nil {
+				command := "sudo service fail2ban " + strings.Join(args, " ")
+				mock.SetError(command, mockError)
+			}
+		})
+
+	if wantError {
+		builder.ExpectError()
+	} else {
+		builder.ExpectSuccess()
+	}
+
+	if wantOutput != "" {
+		builder.ExpectOutput(wantOutput)
+	}
+
+	builder.Run()
 }
 
 func TestServiceCmdWithJSONFormat(t *testing.T) {

--- a/cmd/status_command_refactored_test.go
+++ b/cmd/status_command_refactored_test.go
@@ -52,31 +52,39 @@ func TestStatusCommandRefactored(t *testing.T) {
 	for _, tt := range tests {
 		// Framework approach with fluent interface
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewCommandTest(t, "status").
-				WithArgs(tt.args...).
-				WithSetup(func(mock *fail2ban.MockClient) {
-					setMockJails(mock, tt.jails)
-					if tt.statusAll != "" {
-						mock.StatusAllData = tt.statusAll
-					}
-					if tt.statusJail != nil {
-						mock.StatusJailData = tt.statusJail
-					}
-				})
-
-			if tt.wantError {
-				builder = builder.ExpectError()
-			} else {
-				builder = builder.ExpectSuccess()
-			}
-
-			if tt.wantOutput != "" {
-				builder = builder.ExpectOutput(tt.wantOutput)
-			}
-
-			builder.Run()
+			assertStatusRefactoredCase(t, tt.args, tt.jails, tt.statusAll,
+				tt.statusJail, tt.wantOutput, tt.wantError)
 		})
 	}
+}
+
+// assertStatusRefactoredCase runs a single TestStatusCommandRefactored table case.
+func assertStatusRefactoredCase(t *testing.T, args, jails []string, statusAll string,
+	statusJail map[string]string, wantOutput string, wantError bool) {
+	t.Helper()
+	builder := NewCommandTest(t, "status").
+		WithArgs(args...).
+		WithSetup(func(mock *fail2ban.MockClient) {
+			setMockJails(mock, jails)
+			if statusAll != "" {
+				mock.StatusAllData = statusAll
+			}
+			if statusJail != nil {
+				mock.StatusJailData = statusJail
+			}
+		})
+
+	if wantError {
+		builder = builder.ExpectError()
+	} else {
+		builder = builder.ExpectSuccess()
+	}
+
+	if wantOutput != "" {
+		builder = builder.ExpectOutput(wantOutput)
+	}
+
+	builder.Run()
 }
 
 // TestStatusCommandFrameworkAdvanced shows advanced features of the framework

--- a/fail2ban/fail2ban_ban_record_parser_test.go
+++ b/fail2ban/fail2ban_ban_record_parser_test.go
@@ -91,34 +91,43 @@ func TestBanRecordParser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			record, err := parser.ParseBanRecordLine(tt.line, tt.jail)
-
-			if tt.wantNil {
-				if record != nil {
-					t.Errorf("Expected nil record, got %+v", record)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if record == nil {
-				t.Fatal("Expected record, got nil")
-			} else if record.IP != tt.wantIP {
-				t.Errorf("IP mismatch: got %s, want %s", record.IP, tt.wantIP)
-			}
-
-			if record.Jail != tt.jail {
-				t.Errorf("Jail mismatch: got %s, want %s", record.Jail, tt.jail)
-			}
-
-			// Full-format rows carry a known ban timestamp; assert it exactly
-			// (simple-format rows are skipped inside the helper).
-			validateTimeParsing(t, record, tt.line)
+			assertBanRecordParserCase(t, parser, tt.line, tt.jail, tt.wantIP, tt.wantNil)
 		})
 	}
+}
+
+// assertBanRecordParserCase parses a single line and asserts nil/IP/jail/time
+// expectations for TestBanRecordParser.
+func assertBanRecordParserCase(t *testing.T, parser *BanRecordParser, line, jail, wantIP string, wantNil bool) {
+	t.Helper()
+	record, err := parser.ParseBanRecordLine(line, jail)
+
+	if wantNil {
+		if record != nil {
+			t.Errorf("Expected nil record, got %+v", record)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if record == nil {
+		t.Fatal("Expected record, got nil")
+		return
+	}
+	if record.IP != wantIP {
+		t.Errorf("IP mismatch: got %s, want %s", record.IP, wantIP)
+	}
+
+	if record.Jail != jail {
+		t.Errorf("Jail mismatch: got %s, want %s", record.Jail, jail)
+	}
+
+	// Full-format rows carry a known ban timestamp; assert it exactly
+	// (simple-format rows are skipped inside the helper).
+	validateTimeParsing(t, record, line)
 }
 
 // TestParseBanRecordLineRejectsUnsafeJail exercises the jail-safety guard in
@@ -356,37 +365,46 @@ func TestRealWorldBanRecordPatterns(t *testing.T) {
 
 	for _, tt := range realWorldPatterns {
 		t.Run(tt.name, func(t *testing.T) {
-			records, err := parser.ParseBanRecords(tt.output, tt.jail)
-			if err != nil {
-				t.Fatalf("ParseBanRecords failed: %v", err)
-			}
-
-			if len(records) != tt.wantRecords {
-				t.Errorf("Expected %d records, got %d", tt.wantRecords, len(records))
-			}
-
-			// Check all expected IPs are present
-			ipMap := make(map[string]bool)
-			for _, record := range records {
-				ipMap[record.IP] = true
-
-				// Verify jail
-				if record.Jail != tt.jail {
-					t.Errorf("Record has wrong jail: got %s, want %s", record.Jail, tt.jail)
-				}
-
-				// Verify ban time is parsed
-				if record.BannedAt.IsZero() {
-					t.Errorf("Record for %s has zero ban time", record.IP)
-				}
-			}
-
-			for _, checkIP := range tt.checkIPs {
-				if !ipMap[checkIP] {
-					t.Errorf("Expected IP %s not found in records", checkIP)
-				}
-			}
+			assertRealWorldBanPattern(t, parser, tt.output, tt.jail, tt.wantRecords, tt.checkIPs)
 		})
+	}
+}
+
+// assertRealWorldBanPattern parses a production output block and asserts the
+// record count, jail, non-zero ban times, and expected IP presence.
+func assertRealWorldBanPattern(
+	t *testing.T, parser *BanRecordParser, output, jail string, wantRecords int, checkIPs []string,
+) {
+	t.Helper()
+	records, err := parser.ParseBanRecords(output, jail)
+	if err != nil {
+		t.Fatalf("ParseBanRecords failed: %v", err)
+	}
+
+	if len(records) != wantRecords {
+		t.Errorf("Expected %d records, got %d", wantRecords, len(records))
+	}
+
+	// Check all expected IPs are present
+	ipMap := make(map[string]bool)
+	for _, record := range records {
+		ipMap[record.IP] = true
+
+		// Verify jail
+		if record.Jail != jail {
+			t.Errorf("Record has wrong jail: got %s, want %s", record.Jail, jail)
+		}
+
+		// Verify ban time is parsed
+		if record.BannedAt.IsZero() {
+			t.Errorf("Record for %s has zero ban time", record.IP)
+		}
+	}
+
+	for _, checkIP := range checkIPs {
+		if !ipMap[checkIP] {
+			t.Errorf("Expected IP %s not found in records", checkIP)
+		}
 	}
 }
 

--- a/fail2ban/fail2ban_command_validation_test.go
+++ b/fail2ban/fail2ban_command_validation_test.go
@@ -110,22 +110,27 @@ func TestValidateCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateCommand(tt.command)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("ValidateCommand() expected error but got none")
-					return
-				}
-				if !strings.Contains(err.Error(), tt.errMsg) {
-					t.Errorf("ValidateCommand() error = %v, want error containing %q", err, tt.errMsg)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("ValidateCommand() unexpected error = %v", err)
-				}
-			}
+			assertValidateCommandCase(t, tt.command, tt.wantErr, tt.errMsg)
 		})
+	}
+}
+
+func assertValidateCommandCase(t *testing.T, command string, wantErr bool, errMsg string) {
+	t.Helper()
+	err := ValidateCommand(command)
+
+	if wantErr {
+		if err == nil {
+			t.Errorf("ValidateCommand() expected error but got none")
+			return
+		}
+		if !strings.Contains(err.Error(), errMsg) {
+			t.Errorf("ValidateCommand() error = %v, want error containing %q", err, errMsg)
+		}
+	} else {
+		if err != nil {
+			t.Errorf("ValidateCommand() unexpected error = %v", err)
+		}
 	}
 }
 
@@ -165,18 +170,7 @@ func TestValidateCommandConcurrency(t *testing.T) {
 	for range concurrency {
 		go func() {
 			defer func() { done <- true }()
-			for range iterations {
-				// Test with valid commands
-				if err := ValidateCommand("fail2ban-client"); err != nil {
-					errChan <- err
-					return
-				}
-				// Test with invalid commands
-				if err := ValidateCommand("malicious"); err == nil {
-					errChan <- fmt.Errorf("ValidateCommand should have rejected malicious command")
-					return
-				}
-			}
+			runValidateCommandConcurrencyWorker(errChan, iterations)
 		}()
 	}
 
@@ -191,6 +185,21 @@ func TestValidateCommandConcurrency(t *testing.T) {
 	for err := range errChan {
 		if err != nil {
 			t.Errorf("Concurrent ValidateCommand() failed: %v", err)
+		}
+	}
+}
+
+func runValidateCommandConcurrencyWorker(errChan chan<- error, iterations int) {
+	for range iterations {
+		// Test with valid commands
+		if err := ValidateCommand("fail2ban-client"); err != nil {
+			errChan <- err
+			return
+		}
+		// Test with invalid commands
+		if err := ValidateCommand("malicious"); err == nil {
+			errChan <- fmt.Errorf("ValidateCommand should have rejected malicious command")
+			return
 		}
 	}
 }

--- a/fail2ban/fail2ban_concurrency_test.go
+++ b/fail2ban/fail2ban_concurrency_test.go
@@ -131,53 +131,67 @@ func TestMixedConcurrentOperations(t *testing.T) {
 
 	// Group 1: Set runners (now just validates that setting runners works concurrently)
 	for range numGoroutines / 3 {
-		wg.Go(func() {
-			for range 20 {
-				// Create a new runner with the same responses to test concurrent setting
-				mockRunner := NewMockRunner()
-				mockRunner.SetResponse("fail2ban-client status", []byte("Status: OK"))
-				mockRunner.SetResponse("fail2ban-client -V", []byte("Version: 1.0.0"))
-				mockRunner.SetResponse("sudo fail2ban-client status", []byte("Status: OK"))
-				mockRunner.SetResponse("sudo fail2ban-client -V", []byte("Version: 1.0.0"))
-				SetRunner(mockRunner)
-				time.Sleep(time.Millisecond)
-			}
-		})
+		wg.Go(mixedConcurrentSetRunnerWorker)
 	}
 
 	// Group 2: Execute regular commands (using valid fail2ban commands)
 	for range numGoroutines / 3 {
-		wg.Go(func() {
-			for range 20 {
-				output, err := RunnerCombinedOutput("fail2ban-client", "status")
-				if err != nil {
-					t.Errorf("RunnerCombinedOutput failed: %v", err)
-				}
-				if len(output) == 0 {
-					t.Error("RunnerCombinedOutput returned empty output")
-				}
-				time.Sleep(time.Millisecond)
-			}
-		})
+		wg.Go(func() { mixedConcurrentRegularWorker(t) })
 	}
 
 	// Group 3: Execute sudo commands (using valid fail2ban commands)
 	for range numGoroutines / 3 {
-		wg.Go(func() {
-			for range 20 {
-				output, err := RunnerCombinedOutputWithSudo("fail2ban-client", "-V")
-				if err != nil {
-					t.Errorf("RunnerCombinedOutputWithSudo failed: %v", err)
-				}
-				if len(output) == 0 {
-					t.Error("RunnerCombinedOutputWithSudo returned empty output")
-				}
-				time.Sleep(time.Millisecond)
-			}
-		})
+		wg.Go(func() { mixedConcurrentSudoWorker(t) })
 	}
 
 	wg.Wait()
+}
+
+// mixedConcurrentSetRunnerWorker repeatedly swaps in fresh mock runners to
+// exercise concurrent SetRunner calls.
+func mixedConcurrentSetRunnerWorker() {
+	for range 20 {
+		// Create a new runner with the same responses to test concurrent setting
+		mockRunner := NewMockRunner()
+		mockRunner.SetResponse("fail2ban-client status", []byte("Status: OK"))
+		mockRunner.SetResponse("fail2ban-client -V", []byte("Version: 1.0.0"))
+		mockRunner.SetResponse("sudo fail2ban-client status", []byte("Status: OK"))
+		mockRunner.SetResponse("sudo fail2ban-client -V", []byte("Version: 1.0.0"))
+		SetRunner(mockRunner)
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// mixedConcurrentRegularWorker repeatedly runs a regular command and verifies
+// its output.
+func mixedConcurrentRegularWorker(t *testing.T) {
+	t.Helper()
+	for range 20 {
+		output, err := RunnerCombinedOutput("fail2ban-client", "status")
+		if err != nil {
+			t.Errorf("RunnerCombinedOutput failed: %v", err)
+		}
+		if len(output) == 0 {
+			t.Error("RunnerCombinedOutput returned empty output")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// mixedConcurrentSudoWorker repeatedly runs a sudo command and verifies its
+// output.
+func mixedConcurrentSudoWorker(t *testing.T) {
+	t.Helper()
+	for range 20 {
+		output, err := RunnerCombinedOutputWithSudo("fail2ban-client", "-V")
+		if err != nil {
+			t.Errorf("RunnerCombinedOutputWithSudo failed: %v", err)
+		}
+		if len(output) == 0 {
+			t.Error("RunnerCombinedOutputWithSudo returned empty output")
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 // TestRunnerManagerLockOrdering verifies there are no deadlocks in the

--- a/fail2ban/fail2ban_fail2ban_test.go
+++ b/fail2ban/fail2ban_fail2ban_test.go
@@ -846,36 +846,50 @@ func TestGetBanRecordsWithInvalidTimes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up mock response (the command uses sudo)
-			mockRunner.SetResponse("sudo fail2ban-client get sshd banip --with-time", []byte(tt.mockResponse))
-
-			// Get ban records
-			records, err := client.GetBanRecords([]string{"sshd"})
-			if err != nil {
-				t.Fatalf("GetBanRecords failed: %v", err)
-			}
-
-			// Check count
-			if len(records) != tt.expectedCount {
-				t.Errorf("expected %d records, got %d", tt.expectedCount, len(records))
-			}
-
-			// For entries with invalid unban time (but valid ban time), verify fallback worked
-			if tt.name == "invalid unban time - entry should use fallback" && len(records) > 0 {
-				// The first record should have a reasonable remaining time (not zero)
-				if records[0].Remaining == "00:00:00:00" {
-					t.Errorf("expected fallback time calculation, got zero remaining time")
-				}
-			}
-
-			// For entries using short format fallback
-			if tt.name == "short format fallback" && len(records) > 0 {
-				for _, record := range records {
-					if record.Remaining != "unknown" {
-						t.Errorf("expected 'unknown' remaining time for short format, got %s", record.Remaining)
-					}
-				}
-			}
+			assertInvalidTimeRecords(t, client, mockRunner, tt.name, tt.mockResponse, tt.expectedCount)
 		})
+	}
+}
+
+// assertInvalidTimeRecords runs a single GetBanRecords case for
+// TestGetBanRecordsWithInvalidTimes and verifies count and fallback handling.
+func assertInvalidTimeRecords(
+	t *testing.T,
+	client *RealClient,
+	mockRunner *MockRunner,
+	name, mockResponse string,
+	expectedCount int,
+) {
+	t.Helper()
+
+	// Set up mock response (the command uses sudo)
+	mockRunner.SetResponse("sudo fail2ban-client get sshd banip --with-time", []byte(mockResponse))
+
+	// Get ban records
+	records, err := client.GetBanRecords([]string{"sshd"})
+	if err != nil {
+		t.Fatalf("GetBanRecords failed: %v", err)
+	}
+
+	// Check count
+	if len(records) != expectedCount {
+		t.Errorf("expected %d records, got %d", expectedCount, len(records))
+	}
+
+	// For entries with invalid unban time (but valid ban time), verify fallback worked
+	if name == "invalid unban time - entry should use fallback" && len(records) > 0 {
+		// The first record should have a reasonable remaining time (not zero)
+		if records[0].Remaining == "00:00:00:00" {
+			t.Errorf("expected fallback time calculation, got zero remaining time")
+		}
+	}
+
+	// For entries using short format fallback
+	if name == "short format fallback" && len(records) > 0 {
+		for _, record := range records {
+			if record.Remaining != "unknown" {
+				t.Errorf("expected 'unknown' remaining time for short format, got %s", record.Remaining)
+			}
+		}
 	}
 }

--- a/fail2ban/fail2ban_global_state_race_test.go
+++ b/fail2ban/fail2ban_global_state_race_test.go
@@ -91,18 +91,7 @@ func TestLogDir_ConcurrentSetAndRead(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			counter := 0
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					testDir := fmt.Sprintf("/tmp/writer-%d-count-%d", id, counter)
-					SetLogDir(testDir)
-					counter++
-					time.Sleep(time.Millisecond)
-				}
-			}
+			runConcurrentLogDirWriter(done, id)
 		}(i)
 	}
 
@@ -111,18 +100,7 @@ func TestLogDir_ConcurrentSetAndRead(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					dir := GetLogDir()
-					if dir == "" {
-						errors <- fmt.Sprintf("Reader %d got empty log directory", id)
-					}
-					time.Sleep(time.Millisecond / 2)
-				}
-			}
+			runConcurrentLogDirReader(done, errors, id)
 		}(i)
 	}
 
@@ -135,6 +113,36 @@ func TestLogDir_ConcurrentSetAndRead(t *testing.T) {
 	close(errors)
 	for errMsg := range errors {
 		t.Errorf("%s", errMsg)
+	}
+}
+
+func runConcurrentLogDirWriter(done <-chan struct{}, id int) {
+	counter := 0
+	for {
+		select {
+		case <-done:
+			return
+		default:
+			testDir := fmt.Sprintf("/tmp/writer-%d-count-%d", id, counter)
+			SetLogDir(testDir)
+			counter++
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func runConcurrentLogDirReader(done <-chan struct{}, errors chan<- string, id int) {
+	for {
+		select {
+		case <-done:
+			return
+		default:
+			dir := GetLogDir()
+			if dir == "" {
+				errors <- fmt.Sprintf("Reader %d got empty log directory", id)
+			}
+			time.Sleep(time.Millisecond / 2)
+		}
 	}
 }
 

--- a/fail2ban/fail2ban_gzip_detection_test.go
+++ b/fail2ban/fail2ban_gzip_detection_test.go
@@ -142,31 +142,36 @@ func TestCreateGzipAwareScanner(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scanner, cleanup, err := detector.CreateGzipAwareScanner(tt.file)
-			if err != nil {
-				t.Fatalf("CreateGzipAwareScanner failed: %v", err)
-			}
-			defer cleanup()
-
-			var lines []string
-			for scanner.Scan() {
-				lines = append(lines, scanner.Text())
-			}
-
-			if err := scanner.Err(); err != nil {
-				t.Fatalf("Scanner error: %v", err)
-			}
-
-			if len(lines) != len(tt.expectedLines) {
-				t.Fatalf("Line count = %d, want %d", len(lines), len(tt.expectedLines))
-			}
-
-			for i, line := range lines {
-				if line != tt.expectedLines[i] {
-					t.Errorf("Line %d = %q, want %q", i, line, tt.expectedLines[i])
-				}
-			}
+			assertGzipScanner(t, detector, tt.file, tt.expectedLines)
 		})
+	}
+}
+
+func assertGzipScanner(t *testing.T, detector *GzipDetector, file string, expectedLines []string) {
+	t.Helper()
+	scanner, cleanup, err := detector.CreateGzipAwareScanner(file)
+	if err != nil {
+		t.Fatalf("CreateGzipAwareScanner failed: %v", err)
+	}
+	defer cleanup()
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("Scanner error: %v", err)
+	}
+
+	if len(lines) != len(expectedLines) {
+		t.Fatalf("Line count = %d, want %d", len(lines), len(expectedLines))
+	}
+
+	for i, line := range lines {
+		if line != expectedLines[i] {
+			t.Errorf("Line %d = %q, want %q", i, line, expectedLines[i])
+		}
 	}
 }
 

--- a/fail2ban/fail2ban_integration_sudo_test.go
+++ b/fail2ban/fail2ban_integration_sudo_test.go
@@ -115,35 +115,42 @@ func TestSudoRequirementsIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Modern standardized setup with automatic cleanup
-			_, cleanup := SetupMockEnvironmentWithSudo(t, tt.hasPrivileges)
-			defer cleanup()
-
-			// Get the mock sudo checker and configure based on test case
-			mockChecker := MustMockSudoChecker(t)
-			mockChecker.MockIsRoot = tt.isRoot
-			if tt.isRoot {
-				// Root user always has privileges
-				mockChecker.MockHasPrivileges = true
-			}
-
-			// Test sudo requirements directly
-			err := CheckSudoRequirements()
-
-			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected sudo requirements check to fail")
-				}
-				if !strings.Contains(err.Error(), "fail2ban operations require sudo privileges") {
-					t.Errorf("expected sudo privilege error, got: %v", err)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected sudo requirements error: %v", err)
-			}
+			assertSudoRequirementsCase(t, tt.hasPrivileges, tt.isRoot, tt.expectError)
 		})
+	}
+}
+
+// assertSudoRequirementsCase runs a single TestSudoRequirementsIntegration case.
+func assertSudoRequirementsCase(t *testing.T, hasPrivileges, isRoot, expectError bool) {
+	t.Helper()
+
+	// Modern standardized setup with automatic cleanup
+	_, cleanup := SetupMockEnvironmentWithSudo(t, hasPrivileges)
+	defer cleanup()
+
+	// Get the mock sudo checker and configure based on test case
+	mockChecker := MustMockSudoChecker(t)
+	mockChecker.MockIsRoot = isRoot
+	if isRoot {
+		// Root user always has privileges
+		mockChecker.MockHasPrivileges = true
+	}
+
+	// Test sudo requirements directly
+	err := CheckSudoRequirements()
+
+	if expectError {
+		if err == nil {
+			t.Fatal("expected sudo requirements check to fail")
+		}
+		if !strings.Contains(err.Error(), "fail2ban operations require sudo privileges") {
+			t.Errorf("expected sudo privilege error, got: %v", err)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected sudo requirements error: %v", err)
 	}
 }
 
@@ -256,26 +263,33 @@ func TestSudoErrorPropagation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Modern standardized setup with automatic cleanup
-			_, cleanup := SetupMockEnvironmentWithSudo(t, tt.hasPrivileges)
-			defer cleanup()
-
-			// Test CheckSudoRequirements directly
-			err := CheckSudoRequirements()
-
-			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error but got none")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
-				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-			}
+			assertSudoErrorPropagationCase(t, tt.hasPrivileges, tt.expectError, tt.errorContains)
 		})
+	}
+}
+
+// assertSudoErrorPropagationCase runs a single TestSudoErrorPropagation case.
+func assertSudoErrorPropagationCase(t *testing.T, hasPrivileges, expectError bool, errorContains string) {
+	t.Helper()
+
+	// Modern standardized setup with automatic cleanup
+	_, cleanup := SetupMockEnvironmentWithSudo(t, hasPrivileges)
+	defer cleanup()
+
+	// Test CheckSudoRequirements directly
+	err := CheckSudoRequirements()
+
+	if expectError {
+		if err == nil {
+			t.Fatal("expected error but got none")
+		}
+		if errorContains != "" && !strings.Contains(err.Error(), errorContains) {
+			t.Errorf("expected error to contain %q, got %q", errorContains, err.Error())
+		}
+	} else {
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 	}
 }
 
@@ -349,39 +363,46 @@ func TestSudoWithDifferentCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test RequiresSudo function
-			requiresSudo := RequiresSudo(tt.command, tt.args...)
-			if requiresSudo != tt.expectsSudo {
-				t.Errorf("RequiresSudo(%s, %v) = %v, want %v", tt.command, tt.args, requiresSudo, tt.expectsSudo)
-			}
-
-			// Configure the mock runner with expected response
-			// Note: Reusing outer mock environment to avoid nested cleanup issues
-			mockRunner := MustMockRunner(t)
-			expectedCall := tt.expectedPrefix + " " + strings.Join(tt.args, " ")
-			mockRunner.SetResponse(expectedCall, []byte("mock response"))
-
-			// Execute command using mock runner directly to avoid OSRunner
-			_, err := mockRunner.CombinedOutputWithSudo(tt.command, tt.args...)
-
-			// Check that the expected command was called
-			calls := mockRunner.GetCalls()
-			found := false
-			for _, call := range calls {
-				if strings.HasPrefix(call, tt.expectedPrefix) {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				t.Errorf("Expected command with prefix %q, got calls: %v", tt.expectedPrefix, calls)
-			}
-
-			if err != nil {
-				t.Logf("Command execution resulted in error (may be expected): %v", err)
-			}
+			assertSudoCommandBehavior(t, tt.command, tt.args, tt.expectsSudo, tt.expectedPrefix)
 		})
+	}
+}
+
+// assertSudoCommandBehavior runs a single TestSudoWithDifferentCommands case.
+func assertSudoCommandBehavior(t *testing.T, command string, args []string, expectsSudo bool, expectedPrefix string) {
+	t.Helper()
+
+	// Test RequiresSudo function
+	requiresSudo := RequiresSudo(command, args...)
+	if requiresSudo != expectsSudo {
+		t.Errorf("RequiresSudo(%s, %v) = %v, want %v", command, args, requiresSudo, expectsSudo)
+	}
+
+	// Configure the mock runner with expected response
+	// Note: Reusing outer mock environment to avoid nested cleanup issues
+	mockRunner := MustMockRunner(t)
+	expectedCall := expectedPrefix + " " + strings.Join(args, " ")
+	mockRunner.SetResponse(expectedCall, []byte("mock response"))
+
+	// Execute command using mock runner directly to avoid OSRunner
+	_, err := mockRunner.CombinedOutputWithSudo(command, args...)
+
+	// Check that the expected command was called
+	calls := mockRunner.GetCalls()
+	found := false
+	for _, call := range calls {
+		if strings.HasPrefix(call, expectedPrefix) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected command with prefix %q, got calls: %v", expectedPrefix, calls)
+	}
+
+	if err != nil {
+		t.Logf("Command execution resulted in error (may be expected): %v", err)
 	}
 }
 
@@ -507,42 +528,49 @@ func TestSudoMockConsistency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mock := &MockSudoChecker{
-				MockIsRoot:      tt.isRoot,
-				MockInSudoGroup: tt.inSudoGroup,
-				MockCanUseSudo:  tt.canUseSudo,
-			}
-
-			// Test individual methods
-			if mock.IsRoot() != tt.isRoot {
-				t.Errorf("IsRoot() = %v, want %v", mock.IsRoot(), tt.isRoot)
-			}
-			if mock.InSudoGroup() != tt.inSudoGroup {
-				t.Errorf("InSudoGroup() = %v, want %v", mock.InSudoGroup(), tt.inSudoGroup)
-			}
-			if mock.CanUseSudo() != tt.canUseSudo {
-				t.Errorf("CanUseSudo() = %v, want %v", mock.CanUseSudo(), tt.canUseSudo)
-			}
-
-			// Test combined method
-			if mock.HasSudoPrivileges() != tt.expectedPrivileges {
-				t.Errorf("HasSudoPrivileges() = %v, want %v", mock.HasSudoPrivileges(), tt.expectedPrivileges)
-			}
-
-			// Test that CheckSudoRequirements behaves consistently
-			originalChecker := GetSudoChecker()
-			SetSudoChecker(mock)
-
-			err := CheckSudoRequirements()
-
-			if tt.expectedPrivileges && err != nil {
-				t.Errorf("CheckSudoRequirements() failed when privileges expected: %v", err)
-			}
-			if !tt.expectedPrivileges && err == nil {
-				t.Error("CheckSudoRequirements() succeeded when no privileges expected")
-			}
-
-			SetSudoChecker(originalChecker)
+			assertSudoMockConsistencyCase(t, tt.isRoot, tt.inSudoGroup, tt.canUseSudo, tt.expectedPrivileges)
 		})
 	}
+}
+
+// assertSudoMockConsistencyCase runs a single TestSudoMockConsistency case.
+func assertSudoMockConsistencyCase(t *testing.T, isRoot, inSudoGroup, canUseSudo, expectedPrivileges bool) {
+	t.Helper()
+
+	mock := &MockSudoChecker{
+		MockIsRoot:      isRoot,
+		MockInSudoGroup: inSudoGroup,
+		MockCanUseSudo:  canUseSudo,
+	}
+
+	// Test individual methods
+	if mock.IsRoot() != isRoot {
+		t.Errorf("IsRoot() = %v, want %v", mock.IsRoot(), isRoot)
+	}
+	if mock.InSudoGroup() != inSudoGroup {
+		t.Errorf("InSudoGroup() = %v, want %v", mock.InSudoGroup(), inSudoGroup)
+	}
+	if mock.CanUseSudo() != canUseSudo {
+		t.Errorf("CanUseSudo() = %v, want %v", mock.CanUseSudo(), canUseSudo)
+	}
+
+	// Test combined method
+	if mock.HasSudoPrivileges() != expectedPrivileges {
+		t.Errorf("HasSudoPrivileges() = %v, want %v", mock.HasSudoPrivileges(), expectedPrivileges)
+	}
+
+	// Test that CheckSudoRequirements behaves consistently
+	originalChecker := GetSudoChecker()
+	SetSudoChecker(mock)
+
+	err := CheckSudoRequirements()
+
+	if expectedPrivileges && err != nil {
+		t.Errorf("CheckSudoRequirements() failed when privileges expected: %v", err)
+	}
+	if !expectedPrivileges && err == nil {
+		t.Error("CheckSudoRequirements() succeeded when no privileges expected")
+	}
+
+	SetSudoChecker(originalChecker)
 }

--- a/fail2ban/fail2ban_logs_parsing_test.go
+++ b/fail2ban/fail2ban_logs_parsing_test.go
@@ -273,28 +273,35 @@ func TestGetLogLinesWithRealTestData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lines, err := GetLogLines(context.Background(), tt.jail, tt.ip)
-			if err != nil {
-				t.Fatalf("GetLogLines failed: %v", err)
-			}
-
-			assertMinimumLines(t, lines, tt.wantMinimum, "lines")
-
-			// Check that lines contain expected content
-			if tt.checkLine != "" {
-				assertContainsText(t, lines, tt.checkLine)
-			}
-
-			// Verify filtering works correctly
-			for _, line := range lines {
-				if tt.jail != "" && !strings.Contains(line, "["+tt.jail+"]") && !strings.Contains(line, "rollover") {
-					t.Errorf("Line doesn't match jail filter: %s", line)
-				}
-				if tt.ip != "" && !strings.Contains(line, tt.ip) {
-					t.Errorf("Line doesn't match IP filter: %s", line)
-				}
-			}
+			assertGetLogLinesCase(t, tt.jail, tt.ip, tt.wantMinimum, tt.checkLine)
 		})
+	}
+}
+
+// assertGetLogLinesCase runs GetLogLines for a jail/IP query and asserts the
+// minimum line count, expected content, and per-line filter correctness.
+func assertGetLogLinesCase(t *testing.T, jail, ip string, wantMinimum int, checkLine string) {
+	t.Helper()
+	lines, err := GetLogLines(context.Background(), jail, ip)
+	if err != nil {
+		t.Fatalf("GetLogLines failed: %v", err)
+	}
+
+	assertMinimumLines(t, lines, wantMinimum, "lines")
+
+	// Check that lines contain expected content
+	if checkLine != "" {
+		assertContainsText(t, lines, checkLine)
+	}
+
+	// Verify filtering works correctly
+	for _, line := range lines {
+		if jail != "" && !strings.Contains(line, "["+jail+"]") && !strings.Contains(line, "rollover") {
+			t.Errorf("Line doesn't match jail filter: %s", line)
+		}
+		if ip != "" && !strings.Contains(line, ip) {
+			t.Errorf("Line doesn't match IP filter: %s", line)
+		}
 	}
 }
 
@@ -333,29 +340,38 @@ func TestParseBanRecordsFromRealLogs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			records, err := parser.ParseBanRecords(tt.output, tt.jail)
-			if err != nil {
-				t.Fatalf("ParseBanRecords failed: %v", err)
-			}
-
-			if len(records) != tt.wantCount {
-				t.Errorf("Expected %d records, got %d", tt.wantCount, len(records))
-			}
-
-			// Check for specific IP
-			found := false
-			for _, record := range records {
-				if record.IP == tt.checkIP {
-					found = true
-					if record.Jail != tt.jail {
-						t.Errorf("Record jail mismatch: got %s, want %s", record.Jail, tt.jail)
-					}
-				}
-			}
-			if !found {
-				t.Errorf("Expected to find IP %s in records", tt.checkIP)
-			}
+			assertParsedBanRecordsFromLogs(t, parser, tt.output, tt.jail, tt.wantCount, tt.checkIP)
 		})
+	}
+}
+
+// assertParsedBanRecordsFromLogs parses a ban/unban output block and asserts
+// the record count and that checkIP is present with the expected jail.
+func assertParsedBanRecordsFromLogs(
+	t *testing.T, parser *BanRecordParser, output, jail string, wantCount int, checkIP string,
+) {
+	t.Helper()
+	records, err := parser.ParseBanRecords(output, jail)
+	if err != nil {
+		t.Fatalf("ParseBanRecords failed: %v", err)
+	}
+
+	if len(records) != wantCount {
+		t.Errorf("Expected %d records, got %d", wantCount, len(records))
+	}
+
+	// Check for specific IP
+	found := false
+	for _, record := range records {
+		if record.IP == checkIP {
+			found = true
+			if record.Jail != jail {
+				t.Errorf("Record jail mismatch: got %s, want %s", record.Jail, jail)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Expected to find IP %s in records", checkIP)
 	}
 }
 

--- a/fail2ban/mock_context_test.go
+++ b/fail2ban/mock_context_test.go
@@ -6,9 +6,19 @@ import (
 	"testing"
 )
 
-//nolint:gocyclo // exhaustive table-driven coverage of every mock context method
 func TestMockClientContextMethods(t *testing.T) {
 	mockClient := NewMockClient()
+
+	assertMockContextReadMethods(t, mockClient)
+	assertMockContextMutateMethods(t, mockClient)
+	assertMockContextFilterMethods(t, mockClient)
+	assertMockContextCanceled(t, mockClient)
+}
+
+// assertMockContextReadMethods verifies the status/listing WithContext methods
+// return successfully with non-empty data.
+func assertMockContextReadMethods(t *testing.T, mockClient *MockClient) {
+	t.Helper()
 	ctx := context.Background()
 
 	// Test ListJailsWithContext
@@ -37,6 +47,13 @@ func TestMockClientContextMethods(t *testing.T) {
 	if status == "" {
 		t.Error("Expected jail status output, got empty string")
 	}
+}
+
+// assertMockContextMutateMethods verifies the ban/unban/lookup WithContext
+// methods succeed and return the expected fresh-mock values.
+func assertMockContextMutateMethods(t *testing.T, mockClient *MockClient) {
+	t.Helper()
+	ctx := context.Background()
 
 	// Test BanIPWithContext
 	code, err := mockClient.BanIPWithContext(ctx, "192.168.1.100", "sshd")
@@ -75,6 +92,12 @@ func TestMockClientContextMethods(t *testing.T) {
 	if len(records) != 0 {
 		t.Errorf("Expected empty ban records, got %v", records)
 	}
+}
+
+// assertMockContextFilterMethods verifies the log/filter WithContext methods.
+func assertMockContextFilterMethods(t *testing.T, mockClient *MockClient) {
+	t.Helper()
+	ctx := context.Background()
 
 	// Test GetLogLinesWithContext
 	lines, err := mockClient.GetLogLinesWithContext(ctx, "sshd", "192.168.1.100")
@@ -98,6 +121,12 @@ func TestMockClientContextMethods(t *testing.T) {
 	if err == nil && result == "" {
 		t.Error("Expected test result or error, got neither")
 	}
+}
+
+// assertMockContextCanceled verifies the WithContext wrappers honor a canceled
+// context and return context.Canceled before running the underlying method.
+func assertMockContextCanceled(t *testing.T, mockClient *MockClient) {
+	t.Helper()
 
 	// The WithContext wrappers must honor cancellation: a canceled context
 	// returns its error before the underlying method runs. This exercises the

--- a/main_config_test.go
+++ b/main_config_test.go
@@ -46,46 +46,53 @@ func TestMainConfigurationParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Clear env vars first to ensure clean state
-			t.Setenv("F2B_LOG_DIR", "")
-			t.Setenv("F2B_FILTER_DIR", "")
-
-			// Set up environment using t.Setenv for automatic cleanup
-			if tt.logDirEnv != "" {
-				t.Setenv("F2B_LOG_DIR", tt.logDirEnv)
-			}
-			if tt.filterDirEnv != "" {
-				t.Setenv("F2B_FILTER_DIR", tt.filterDirEnv)
-			}
-
-			// Build config from env (mimic main function)
-			config := struct {
-				LogDir    string
-				FilterDir string
-				Format    string
-			}{}
-
-			config.LogDir = os.Getenv("F2B_LOG_DIR")
-			if config.LogDir == "" {
-				config.LogDir = "/var/log"
-			}
-			config.FilterDir = os.Getenv("F2B_FILTER_DIR")
-			if config.FilterDir == "" {
-				config.FilterDir = "/etc/fail2ban/filter.d"
-			}
-			config.Format = "plain"
-
-			// Verify configuration values
-			if config.LogDir != tt.expectedLogDir {
-				t.Errorf("expected LogDir=%q, got %q", tt.expectedLogDir, config.LogDir)
-			}
-			if config.FilterDir != tt.expectedFilterDir {
-				t.Errorf("expected FilterDir=%q, got %q", tt.expectedFilterDir, config.FilterDir)
-			}
-			if config.Format != "plain" {
-				t.Errorf("expected Format=%q, got %q", "plain", config.Format)
-			}
+			runMainConfigCase(t, tt.logDirEnv, tt.filterDirEnv, tt.expectedLogDir, tt.expectedFilterDir)
 		})
+	}
+}
+
+// runMainConfigCase mimics main's env-driven config build and verifies the
+// resolved LogDir/FilterDir/Format for a single parsing case.
+func runMainConfigCase(t *testing.T, logDirEnv, filterDirEnv, expectedLogDir, expectedFilterDir string) {
+	t.Helper()
+	// Clear env vars first to ensure clean state
+	t.Setenv("F2B_LOG_DIR", "")
+	t.Setenv("F2B_FILTER_DIR", "")
+
+	// Set up environment using t.Setenv for automatic cleanup
+	if logDirEnv != "" {
+		t.Setenv("F2B_LOG_DIR", logDirEnv)
+	}
+	if filterDirEnv != "" {
+		t.Setenv("F2B_FILTER_DIR", filterDirEnv)
+	}
+
+	// Build config from env (mimic main function)
+	config := struct {
+		LogDir    string
+		FilterDir string
+		Format    string
+	}{}
+
+	config.LogDir = os.Getenv("F2B_LOG_DIR")
+	if config.LogDir == "" {
+		config.LogDir = "/var/log"
+	}
+	config.FilterDir = os.Getenv("F2B_FILTER_DIR")
+	if config.FilterDir == "" {
+		config.FilterDir = "/etc/fail2ban/filter.d"
+	}
+	config.Format = "plain"
+
+	// Verify configuration values
+	if config.LogDir != expectedLogDir {
+		t.Errorf("expected LogDir=%q, got %q", expectedLogDir, config.LogDir)
+	}
+	if config.FilterDir != expectedFilterDir {
+		t.Errorf("expected FilterDir=%q, got %q", expectedFilterDir, config.FilterDir)
+	}
+	if config.Format != "plain" {
+		t.Errorf("expected Format=%q, got %q", "plain", config.Format)
 	}
 }
 

--- a/main_performance_test.go
+++ b/main_performance_test.go
@@ -31,56 +31,76 @@ func BenchmarkE2E_MainAPIs(b *testing.B) {
 	// Setup mock client
 	client := setupBenchmarkClient(b)
 
-	b.Run("GetLogLines", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := fail2ban.GetLogLines(context.Background(), "sshd", "192.168.1.100")
-			if err != nil {
-				b.Fatalf("GetLogLines failed: %v", err)
-			}
-		}
-	})
-
-	b.Run("GetLogLinesWithLimit", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := fail2ban.GetLogLinesWithLimit(context.Background(), "sshd", "192.168.1.100", 100)
-			if err != nil {
-				b.Fatalf("GetLogLinesWithLimit failed: %v", err)
-			}
-		}
-	})
-
-	b.Run("UltraOptimized", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := fail2ban.GetLogLinesUltraOptimized("sshd", "192.168.1.100", 100)
-			if err != nil {
-				b.Fatalf("GetLogLinesUltraOptimized failed: %v", err)
-			}
-		}
-	})
-
+	b.Run("GetLogLines", benchE2EGetLogLines)
+	b.Run("GetLogLinesWithLimit", benchE2EGetLogLinesWithLimit)
+	b.Run("UltraOptimized", benchE2EUltraOptimized)
 	b.Run("Client_GetBanRecords", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := client.GetBanRecords([]string{"sshd"})
-			if err != nil {
-				b.Fatalf("GetBanRecords failed: %v", err)
-			}
-		}
+		benchE2EClientGetBanRecords(b, client)
 	})
-
 	b.Run("Client_GetBanRecordsWithContext", func(b *testing.B) {
-		ctx := context.Background()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := client.GetBanRecordsWithContext(ctx, []string{"sshd"})
-			if err != nil {
-				b.Fatalf("GetBanRecordsWithContext failed: %v", err)
-			}
-		}
+		benchE2EClientGetBanRecordsWithContext(b, client)
 	})
+}
+
+// benchE2EGetLogLines benchmarks fail2ban.GetLogLines.
+func benchE2EGetLogLines(b *testing.B) {
+	b.Helper()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := fail2ban.GetLogLines(context.Background(), "sshd", "192.168.1.100")
+		if err != nil {
+			b.Fatalf("GetLogLines failed: %v", err)
+		}
+	}
+}
+
+// benchE2EGetLogLinesWithLimit benchmarks fail2ban.GetLogLinesWithLimit.
+func benchE2EGetLogLinesWithLimit(b *testing.B) {
+	b.Helper()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := fail2ban.GetLogLinesWithLimit(context.Background(), "sshd", "192.168.1.100", 100)
+		if err != nil {
+			b.Fatalf("GetLogLinesWithLimit failed: %v", err)
+		}
+	}
+}
+
+// benchE2EUltraOptimized benchmarks fail2ban.GetLogLinesUltraOptimized.
+func benchE2EUltraOptimized(b *testing.B) {
+	b.Helper()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := fail2ban.GetLogLinesUltraOptimized("sshd", "192.168.1.100", 100)
+		if err != nil {
+			b.Fatalf("GetLogLinesUltraOptimized failed: %v", err)
+		}
+	}
+}
+
+// benchE2EClientGetBanRecords benchmarks client.GetBanRecords.
+func benchE2EClientGetBanRecords(b *testing.B, client *fail2ban.RealClient) {
+	b.Helper()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := client.GetBanRecords([]string{"sshd"})
+		if err != nil {
+			b.Fatalf("GetBanRecords failed: %v", err)
+		}
+	}
+}
+
+// benchE2EClientGetBanRecordsWithContext benchmarks client.GetBanRecordsWithContext.
+func benchE2EClientGetBanRecordsWithContext(b *testing.B, client *fail2ban.RealClient) {
+	b.Helper()
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := client.GetBanRecordsWithContext(ctx, []string{"sshd"})
+		if err != nil {
+			b.Fatalf("GetBanRecordsWithContext failed: %v", err)
+		}
+	}
 }
 
 // BenchmarkMemoryAllocation_Critical benchmarks memory allocations in critical paths

--- a/main_security_test.go
+++ b/main_security_test.go
@@ -330,29 +330,41 @@ func TestSecurityAudit_ErrorMessages(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				errorMsg, err := tc.testFunc()
-				if err == nil {
-					// These are all validators fed clearly malicious input; a
-					// missing error is a security regression, not a reason to
-					// skip the leakage checks.
-					t.Fatalf("%s: expected a validation error for malicious input", tc.name)
-				}
-
-				// Check that error message doesn't contain sensitive information
-				lowerErrorMsg := strings.ToLower(errorMsg)
-				for _, pattern := range sensitivePatterns {
-					if strings.Contains(lowerErrorMsg, strings.ToLower(pattern)) {
-						t.Errorf("Error message contains sensitive pattern '%s': %s", pattern, errorMsg)
-					}
-				}
-
-				// Check that error message is not too verbose
-				if len(errorMsg) > 200 {
-					t.Errorf("Error message is too verbose (>200 chars): %s", errorMsg)
-				}
+				assertErrorMessageNoLeak(t, tc.name, tc.testFunc, sensitivePatterns)
 			})
 		}
 	})
+}
+
+// assertErrorMessageNoLeak runs a validator-error case and verifies the message
+// exists, stays under 200 chars, and leaks none of sensitivePatterns.
+func assertErrorMessageNoLeak(
+	t *testing.T,
+	name string,
+	testFunc func() (string, error),
+	sensitivePatterns []string,
+) {
+	t.Helper()
+	errorMsg, err := testFunc()
+	if err == nil {
+		// These are all validators fed clearly malicious input; a
+		// missing error is a security regression, not a reason to
+		// skip the leakage checks.
+		t.Fatalf("%s: expected a validation error for malicious input", name)
+	}
+
+	// Check that error message doesn't contain sensitive information
+	lowerErrorMsg := strings.ToLower(errorMsg)
+	for _, pattern := range sensitivePatterns {
+		if strings.Contains(lowerErrorMsg, strings.ToLower(pattern)) {
+			t.Errorf("Error message contains sensitive pattern '%s': %s", pattern, errorMsg)
+		}
+	}
+
+	// Check that error message is not too verbose
+	if len(errorMsg) > 200 {
+		t.Errorf("Error message is too verbose (>200 chars): %s", errorMsg)
+	}
 }
 
 // TestSecurityAudit_PrivilegeEscalation tests for privilege escalation vulnerabilities
@@ -436,24 +448,12 @@ func testSecurityChainValidation(t *testing.T, jail, ip string, shouldPass, test
 	t.Helper()
 	// Validate jail if we should test it
 	if testJail {
-		err := fail2ban.ValidateJail(jail)
-		if shouldPass && err != nil {
-			t.Errorf("Legitimate jail should pass: %v", err)
-		}
-		if !shouldPass && err == nil {
-			t.Errorf("Malicious jail should be rejected")
-		}
+		assertChainJailValidation(t, jail, shouldPass)
 	}
 
 	// Validate IP if we should test it
 	if testIP {
-		err := fail2ban.ValidateIP(ip)
-		if shouldPass && err != nil {
-			t.Errorf("Legitimate IP should pass: %v", err)
-		}
-		if !shouldPass && err == nil {
-			t.Errorf("Malicious IP should be rejected")
-		}
+		assertChainIPValidation(t, ip, shouldPass)
 	}
 
 	// Test end-to-end log reading (only for legitimate cases)
@@ -462,6 +462,30 @@ func testSecurityChainValidation(t *testing.T, jail, ip string, shouldPass, test
 		if err != nil {
 			t.Errorf("Legitimate log reading should succeed: %v", err)
 		}
+	}
+}
+
+// assertChainJailValidation checks ValidateJail's verdict matches shouldPass.
+func assertChainJailValidation(t *testing.T, jail string, shouldPass bool) {
+	t.Helper()
+	err := fail2ban.ValidateJail(jail)
+	if shouldPass && err != nil {
+		t.Errorf("Legitimate jail should pass: %v", err)
+	}
+	if !shouldPass && err == nil {
+		t.Errorf("Malicious jail should be rejected")
+	}
+}
+
+// assertChainIPValidation checks ValidateIP's verdict matches shouldPass.
+func assertChainIPValidation(t *testing.T, ip string, shouldPass bool) {
+	t.Helper()
+	err := fail2ban.ValidateIP(ip)
+	if shouldPass && err != nil {
+		t.Errorf("Legitimate IP should pass: %v", err)
+	}
+	if !shouldPass && err == nil {
+		t.Errorf("Malicious IP should be rejected")
 	}
 }
 


### PR DESCRIPTION
## Summary

Sweeps every remaining test function above the SonarCloud `go:S3776` cognitive-complexity threshold (15). These are **pre-existing** functions that were never surfaced on a PR diff (so they never appeared in a PR's SonarCloud report) but show on `main`'s full-project dashboard. After this, the **whole tree reports zero functions over complexity 15**.

**26 functions across 18 test files**, all fixed with the same mechanical pattern: extract branchy subtest/table-case bodies into uniquely-named `t.Helper()` helpers. **No behavior change** — assertions, messages, and coverage preserved verbatim; verified by the full suite.

## Scope

| Package | Functions |
| --- | --- |
| `main` | `TestSecurityAudit_ErrorMessages` (28), `BenchmarkE2E_MainAPIs` (26), `TestMainConfigurationParsing` (22), `testSecurityChainValidation` (17) |
| `fail2ban` | `TestMixedConcurrentOperations` (28), `TestGetBanRecordsWithInvalidTimes` (28), `TestRealWorldBanRecordPatterns` (26), `TestParseBanRecordsFromRealLogs` (23), `TestMockClientContextMethods` (22), `TestLogDir_ConcurrentSetAndRead` (22), `TestSudoMockConsistency` (21), `TestGetLogLinesWithRealTestData` (20), `TestCreateGzipAwareScanner` (20), `TestBanRecordParser` (19), `TestSudoRequirementsIntegration` (18), `TestSudoWithDifferentCommands` (17), `TestSudoErrorPropagation` (17), `TestValidateCommand` (16), `TestValidateCommandConcurrency` (16) |
| `cmd` | `TestPrintError` (25), `TestLogsWatchCmd` (21), `MockLogsWatchClient.GetLogLines` (17), `TestStatusCommandRefactored` (16), `TestStatusCommand` (16), `TestServiceCmd` (16), `TestExecuteIntegration` (16) |

## Verification

- `go build ./...`, `go test ./...` — pass
- `golangci-lint run` — **0 issues** (thelper, revive `context-as-argument`, nolintlint, gocognit all satisfied)
- `gocognit -over 15` on the whole tree — **no functions reported**

## Note

Concurrency tests keep their goroutine/sync structure intact (only per-worker/per-case bodies were extracted), so race semantics are unchanged.
